### PR TITLE
Update README.md noting binding to more than localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,10 @@ This can be done using mkdocs:
 $ mkdocs serve
 ```
 
+To bind to any address/interface (0.0.0.0) or an IP address use:
+
+```
+$ mkdocs serve --dev-addr <IP Address>:8000
+```
+
 This will generate the documentation and serve it using a webserver on localhost for viewing.


### PR DESCRIPTION
Binding to non-localhost was enabled in https://github.com/mkdocs/mkdocs/pull/2111 so note how to enable it for users who want to use it on an internal server for development teams.


I did this in a hurry so feel free to suggest or edit the text.