### PR TITLE
astxml2markdown.xslt: Omit parentheses on apps/functions in side nav.

### DIFF
--- a/utils/astxml2markdown.xslt
+++ b/utils/astxml2markdown.xslt
@@ -13,6 +13,8 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 </xsl:template>
 
 <xsl:template match="application">
+    <xsl:text>Title: </xsl:text><xsl:value-of select="@name"/><xsl:text></xsl:text>
+    <xsl:text>&#10;&#10;</xsl:text>
     <xsl:text># </xsl:text><xsl:value-of select="@name"/><xsl:text>()</xsl:text>
     <xsl:choose>
         <xsl:when test="@module">
@@ -39,6 +41,8 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 </xsl:template>
 
 <xsl:template match="function">
+    <xsl:text>Title: </xsl:text><xsl:value-of select="@name"/><xsl:text></xsl:text>
+    <xsl:text>&#10;&#10;</xsl:text>
     <xsl:text># </xsl:text><xsl:value-of select="@name"/><xsl:text>()</xsl:text>
     <xsl:choose>
         <xsl:when test="@module">

--- a/utils/astxml2markdown.xslt
+++ b/utils/astxml2markdown.xslt
@@ -13,8 +13,9 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 </xsl:template>
 
 <xsl:template match="application">
-    <xsl:text>Title: </xsl:text><xsl:value-of select="@name"/><xsl:text></xsl:text>
-    <xsl:text>&#10;&#10;</xsl:text>
+    <xsl:text>---&#10;</xsl:text>
+    <xsl:text>title: </xsl:text><xsl:value-of select="@name"/><xsl:text>&#10;</xsl:text>
+    <xsl:text>---&#10;&#10;</xsl:text>
     <xsl:text># </xsl:text><xsl:value-of select="@name"/><xsl:text>()</xsl:text>
     <xsl:choose>
         <xsl:when test="@module">
@@ -41,8 +42,9 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 </xsl:template>
 
 <xsl:template match="function">
-    <xsl:text>Title: </xsl:text><xsl:value-of select="@name"/><xsl:text></xsl:text>
-    <xsl:text>&#10;&#10;</xsl:text>
+    <xsl:text>---&#10;</xsl:text>
+    <xsl:text>title: </xsl:text><xsl:value-of select="@name"/><xsl:text>&#10;</xsl:text>
+    <xsl:text>---&#10;&#10;</xsl:text>
     <xsl:text># </xsl:text><xsl:value-of select="@name"/><xsl:text>()</xsl:text>
     <xsl:choose>
         <xsl:when test="@module">


### PR DESCRIPTION
This also removes the trailing `- \[module\]` text that some apps/functions are currently displaying in the side nav.