### PR TITLE
Fix a misleading IPv6 ACL example in Named ACLs

### DIFF
--- a/docs/Configuration/Core-Configuration/Named-ACLs.md
+++ b/docs/Configuration/Core-Configuration/Named-ACLs.md
@@ -66,7 +66,7 @@ permit=10.24.20.3
 
 ```
 [ipv6_example_1]
-deny = ::
+deny = ::/0
 permit = ::1/128
 
 [ipv6_example_2]


### PR DESCRIPTION
"deny=::" is equivalent to "::/128".
In order to mean "deny everything by default" it must be "::/0".