### PR TITLE
Makefile: Fix path to Asterisk_REST_Data_Models.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ dynamic-core-setup: branch-check $(BUILD_DIR)/docs $(BRANCH_DIR) $(XML_PREREQ)
 	@ln -sfr $(BRANCH_DIR)/docs $(BUILD_DIR)/docs/$(BRANCH_DOC_DIR)/API_Documentation 
 
 ifneq ($(ASTERISK_ARI_DIR),)
-  ARI_PREREQ := $(ASTERISK_ARI_DIR)/_Asterisk_REST_Data_Models.md
+  ARI_PREREQ := $(ASTERISK_ARI_DIR)/Asterisk_REST_Data_Models.md
 else
   ARI_PREREQ := download-from-job
   ASTERISK_ARI_DIR := $(BRANCH_DIR)/source/


### PR DESCRIPTION
When building from local ARI documentation, the path to the
Asterisk_REST_Data_Models.md had an '_' prepended to it which
was left over from the very early process and caused the current
process to fail.  It's now removed.
