### PR TITLE
Use kbd tag when referring to keys on keyboard

### DIFF
--- a/docs/Configuration/Applications/External-IVR-Interface.md
+++ b/docs/Configuration/Applications/External-IVR-Interface.md
@@ -67,10 +67,10 @@ texttag,timestamp[,data]
 
 The tag can be one of the following characters:
 
-* `0-9` - DTMF event for keys 0 through 9
-* `A-D` - DTMF event for keys A through D
-* `*` - DTMF event for key \*
-* `#` - DTMF event for key #
+* `0-9` - DTMF event for keys <kbd>0</kbd> through <kbd>9</kbd>
+* `A-D` - DTMF event for keys <kbd>A</kbd> through <kbd>D</kbd>
+* `*` - DTMF event for key <kbd>*</kbd>
+* `#` - DTMF event for key <kbd>#</kbd>
 * `H` - The channel was hung up by the connected party
 * `E` - The script requested an exit
 * `Z` - The previous command was unable to be executed. There may be a data element if appropriate, see specific commands below for details

--- a/docs/Configuration/Dialplan/Special-Dialplan-Extensions.md
+++ b/docs/Configuration/Dialplan/Special-Dialplan-Extensions.md
@@ -22,7 +22,7 @@ Here we'll list all of the special built-in dialplan extensions and their usage.
 a: Assistant extension
 ----------------------
 
-This extension is similar to the **o** extension, only it gets triggered when the caller presses the asterisk (\*) key while recording a voice mail message. This is typically used to reach an assistant.
+This extension is similar to the **o** extension, only it gets triggered when the caller presses the asterisk (<kbd>*</kbd>) key while recording a voice mail message. This is typically used to reach an assistant.
 
 e: Exception Catchall extension
 -------------------------------

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Channels/ARI-and-Channels-Handling-DTMF.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Channels/ARI-and-Channels-Handling-DTMF.md
@@ -16,7 +16,7 @@ While this concept is relatively straight forward, handling DTMF is quite common
 This example mimics the [automated attendant/IVR dialplan example](/Deployment/Basic-PBX-Functionality/Auto-attendant-and-IVR-Menus/Handling-Special-Extensions). It does the following:
 
 * Plays a menu to the user which is cancelled when the user takes some action.
-* If the user presses 1 or 2, the digit is repeated to the user and the menu restarted.
+* If the user presses <kbd>1</kbd> or <kbd>2</kbd>, the digit is repeated to the user and the menu restarted.
 * If the user presses an invalid digit, a prompt informing the user that the digit was invalid is played to the user and the menu restarted.
 * If the user fails to press anything within some period of time, a prompt asking the user if they are still present is played to the user and the menu restarted.
 
@@ -350,7 +350,7 @@ def cancel_timeout(channel):
 
 ```
 
-Finally, we need to actually do *something* when the user presses a `1` or a `2`. We could do anything here - but in our case, we're merely going to play back the number that they pressed and restart the menu.
+Finally, we need to actually do *something* when the user presses a <kbd>1</kbd> or a <kbd>2</kbd>. We could do anything here - but in our case, we're merely going to play back the number that they pressed and restart the menu.
 
 ```python
 def handle_extension_one(channel):
@@ -586,7 +586,7 @@ client.run(apps='channel-aa')
 
 ### channel-aa.py in action
 
-The following shows the output of `channel-aa.py` when a PJSIP channel presses `1`, `2`, `8`, then times out. Finally they hang up.
+The following shows the output of `channel-aa.py` when a PJSIP channel presses <kbd>1</kbd>, <kbd>2</kbd>, <kbd>8</kbd>, then times out. Finally they hang up.
 
 ```
 Channel PJSIP/alice-00000001 has entered the application
@@ -833,7 +833,7 @@ function cancelTimeout(channel) {
 
 ```
 
-Finally, we need to actually do *something* when the user presses a `1` or a `2`. We could do anything here - but in our case, we're merely going to play back the number that they pressed and restart the menu.
+Finally, we need to actually do *something* when the user presses a <kbd>1</kbd> or a <kbd>2</kbd>. We could do anything here - but in our case, we're merely going to play back the number that they pressed and restart the menu.
 
 ```javascript
 function handleDtmf(channel, digit) {
@@ -1038,7 +1038,7 @@ function clientLoaded (err, client) {
 
 ### channel-aa.js in action
 
-The following shows the output of `channel-aa.js` when a PJSIP channel presses `1`, `2`, `8`, then times out. Finally they hang up.
+The following shows the output of `channel-aa.js` when a PJSIP channel presses <kbd>1</kbd>, <kbd>2</kbd>, <kbd>8</kbd>, then times out. Finally they hang up.
 
 ```
 Channel PJSIP/alice-00000001 has entered the application

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/ARI-and-Media-Part-1-Recording.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/ARI-and-Media-Part-1-Recording.md
@@ -142,7 +142,7 @@ This way, when calling any three-digit extension that begins with the number '3'
 Basic Voice Mail Recording
 ==========================
 
-We've seen a lot of the underlying concepts for our application, so let's actually make something useful now. We'll start with a very simple application that allows callers to record a message upon entering the application. When the caller has completed recording the message, the caller may press the '#' key or may hang up to accept the recording. Here is a state machine diagram for the application:
+We've seen a lot of the underlying concepts for our application, so let's actually make something useful now. We'll start with a very simple application that allows callers to record a message upon entering the application. When the caller has completed recording the message, the caller may press the <kbd>#</kbd> key or may hang up to accept the recording. Here is a state machine diagram for the application:
 
 ![](record.png)
 
@@ -372,7 +372,7 @@ var HungUpState = require('./hungup_state');
 
 ```
 
-The following is a sample output of a user calling the application and pressing the '#' key when finished recording
+The following is a sample output of a user calling the application and pressing the <kbd>#</kbd> key when finished recording
 
 ```
 Channel PJSIP/200-00000003 recording voicemail for 305
@@ -391,7 +391,7 @@ silverseagreenReader Exercise 1solidblackCurrently, the voicemails being recorde
 Cancelling a Recording
 ======================
 
-Now we have a simple application set up to record a message, but it's pretty bare at the moment. Let's start expanding some. One feature we can add is the ability to press a DTMF key while recording a voice mail to cancel the current recording and re-start the recording process. We'll use the DTMF '\*' key to accomplish this. The updated state machine diagram looks like the following:
+Now we have a simple application set up to record a message, but it's pretty bare at the moment. Let's start expanding some. One feature we can add is the ability to press a DTMF key while recording a voice mail to cancel the current recording and re-start the recording process. We'll use the DTMF <kbd>*</kbd> key to accomplish this. The updated state machine diagram looks like the following:
 
 ![](record-with-retry.png)
 
@@ -446,7 +446,7 @@ jstrue function on_dtmf(event, channel) {
 
 ```
 
-The first part of the method is the same as it was before, but we have added extra handling for when the user presses the '\*' key. The `cancel()` method for live recordings causes the live recording to be stopped and for it not to be stored on the file system.
+The first part of the method is the same as it was before, but we have added extra handling for when the user presses the <kbd>*</kbd> key. The `cancel()` method for live recordings causes the live recording to be stopped and for it not to be stored on the file system.
 
 We also need to add our new transition while setting up our state machine. Our `VoiceMailCall::setup_state_machine()` method now looks like:
 
@@ -488,7 +488,7 @@ jstruethis.setup_state_machine = function() {
 
 ```
 
-This is exactly the same as it was, except for the penultimate line adding the ``Event.DTMF_STAR`` transition. Here is sample output for when a user calls in, presses '\*' twice, and then presses '#' to complete the call
+This is exactly the same as it was, except for the penultimate line adding the ``Event.DTMF_STAR`` transition. Here is sample output for when a user calls in, presses <kbd>*</kbd> twice, and then presses <kbd>#</kbd> to complete the call
 
 ```
 Channel PJSIP/200-00000007 recording voicemail for 305
@@ -519,7 +519,7 @@ Modify the `RecordingState` to allow for a DTMF digit of your choice to cancel t
 Operating on Stored Recordings
 ==============================
 
-So far, we've recorded a channel, stopped a live recording, and cancelled a live recording. Now let's turn our attention to operations that can be performed on stored recordings. An obvious operation to start with is to play back the stored recording. We're going to make another modification to our voice mail recording application that adds a "reviewing" state after a voicemail is recorded. In this state, a user that has recorded a voice mail will hear the recorded message played back to him/her. The user may press the '#' key or hang up in order to accept the recorded message, or the user may press '\*' to erase the stored recording and record a new message in its place. Below is the updated state diagram with the new "reviewing" state added.
+So far, we've recorded a channel, stopped a live recording, and cancelled a live recording. Now let's turn our attention to operations that can be performed on stored recordings. An obvious operation to start with is to play back the stored recording. We're going to make another modification to our voice mail recording application that adds a "reviewing" state after a voicemail is recorded. In this state, a user that has recorded a voice mail will hear the recorded message played back to him/her. The user may press the <kbd>#</kbd> key or hang up in order to accept the recorded message, or the user may press <kbd>*</kbd> to erase the stored recording and record a new message in its place. Below is the updated state diagram with the new "reviewing" state added.
 
 ![](record-with-review.png)
 
@@ -712,7 +712,7 @@ this.setup_state_machine = function() {
 
 ```
 
-The following is the output from a sample call. The user records audio, then presses '#'. Upon hearing the recording, the user decides to record again, so the user presses '\*'. After re-recording, the user presses '#'. The user hears the new version of the recording played back and is satisfied with it, so the user presses '#' to accept the recording.
+The following is the output from a sample call. The user records audio, then presses <kbd>#</kbd>. Upon hearing the recording, the user decides to record again, so the user presses <kbd>*</kbd>. After re-recording, the user presses <kbd>#</kbd>. The user hears the new version of the recording played back and is satisfied with it, so the user presses <kbd>#</kbd> to accept the recording.
 
 ```
 Channel PJSIP/200-00000009 recording voicemail for 305
@@ -734,9 +734,9 @@ Ending voice mail call from PJSIP/200-00000009
 
 silverseagreenReader Exercise 5solidblackIn the previous section we introduced the ability to delete a stored recording. Stored recordings have a second operation available to them: [copying](/Latest_API/API_Documentation/Asterisk_REST_Interface/Recordings_REST_API/#copystored). The `copy()` method of a stored recording can be used to copy the stored recording from one location to another.
 
-For this exercise modify `ReviewingState` to let a DTMF key of your choice copy the message to a different mailbox on the system. When a user presses this DTMF key, the state machine should transition into a new state called "copying." The "copying" state should gather DTMF from the user to determine which mailbox the message should be copied to. If '#' is entered, then the message is sent to the mailbox the user has typed in. If '\*' is entered, then the copying operation is cancelled. Both a '#' and a '\*' should cause the state machine to transition back into `ReviewingState`.
+For this exercise modify `ReviewingState` to let a DTMF key of your choice copy the message to a different mailbox on the system. When a user presses this DTMF key, the state machine should transition into a new state called "copying." The "copying" state should gather DTMF from the user to determine which mailbox the message should be copied to. If <kbd>#</kbd> is entered, then the message is sent to the mailbox the user has typed in. If <kbd>*</kbd> is entered, then the copying operation is cancelled. Both a <kbd>#</kbd> and a <kbd>*</kbd> should cause the state machine to transition back into `ReviewingState`.
 
-As an example, let's say that you have set DTMF '0' to be the key that the user presses in `ReviewingState` to copy the message. The user presses '0'. The user then presses '3' '2' '0' '#'. The message should be copied to mailbox "320", and the user should start hearing the message played back again. Now let's say the user presses '0' to copy the message again. The user then presses '3' '2' '1' '0' '\*'. The message should not be copied to any mailbox, and the user should start hearing the message played back again.
+As an example, let's say that you have set DTMF <kbd>0</kbd> to be the key that the user presses in `ReviewingState` to copy the message. The user presses <kbd>0</kbd>. The user then presses <kbd>3</kbd> <kbd>2</kbd> <kbd>0</kbd> <kbd>#</kbd>. The message should be copied to mailbox "320", and the user should start hearing the message played back again. Now let's say the user presses <kbd>0</kbd> to copy the message again. The user then presses <kbd>3</kbd> <kbd>2</kbd> <kbd>1</kbd> <kbd>0</kbd> <kbd>*</kbd>. The message should not be copied to any mailbox, and the user should start hearing the message played back again.
 
 Recording Bridges
 =================

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/ARI-and-Media-Part-2-Playbacks.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/ARI-and-Media-Part-2-Playbacks.md
@@ -210,7 +210,7 @@ this.setup_state_machine = function() {
 
 ```
 
-Here is a sample run where the user cuts off the greeting by pressing the '#' key, records a greeting and presses the '#' key, and after listening to the recording presses the '#' key once more.
+Here is a sample run where the user cuts off the greeting by pressing the <kbd>#</kbd> key, records a greeting and presses the <kbd>#</kbd> key, and after listening to the recording presses the <kbd>#</kbd> key once more.
 
 ```
 Channel PJSIP/200-0000000b recording voicemail for 305
@@ -237,14 +237,14 @@ So far in our voice mail application, we have stopped playbacks, but there are a
 
 For this, we will write a new application. This new application will allow a caller to listen to the voicemails that are stored in a specific mailbox. When the caller enters the application, a prompt is played to the caller saying which message number the caller is hearing. When the message number finishes playing (or if the caller interrupts the playback with '#'), then the caller hears the specified message in the voicemail box. While listening to the voicemail, the caller can do several things:
 
-* Press the '1' key to go back 3 seconds in the current message playback.
-* Press the '2' key to pause or unpause the current message playback.
-* Press the '3' key to go forward 3 seconds in the current message playback.
-* Press the '4' key to play to the previous message.
-* Press the '5' key to restart the current message playback.
-* Press the '6' key to play to the next message.
-* Press the '\*' key to delete the current message and play the next message.
-* Press the '#' key to end the call.
+* Press the <kbd>1</kbd>' key to go back 3 seconds in the current message playback.
+* Press the <kbd>2</kbd> key to pause or unpause the current message playback.
+* Press the <kbd>3</kbd> key to go forward 3 seconds in the current message playback.
+* Press the <kbd>4</kbd> key to play to the previous message.
+* Press the <kbd>5</kbd> key to restart the current message playback.
+* Press the <kbd>6</kbd> key to play to the next message.
+* Press the <kbd>*</kbd> key to delete the current message and play the next message.
+* Press the <kbd>#</kbd> key to end the call.
 
 If all messages in a mailbox are deleted or if the mailbox contained no messages to begin with, then "no more messages" is played back to the user, and the call is completed.
 

--- a/docs/Deployment/Basic-PBX-Functionality/Auto-attendant-and-IVR-Menus/Record-Application.md
+++ b/docs/Deployment/Basic-PBX-Functionality/Auto-attendant-and-IVR-Menus/Record-Application.md
@@ -3,7 +3,7 @@ title: Record Application
 pageid: 4817379
 ---
 
-For creating your own auto-attendant or IVR menus, you're probably going to want to record your own custom prompts. An easy way to do this is with the **Record()** application. The **Record()** application plays a beep, and then begins recording audio until you press the hash key (**#**) on your keypad. It then saves the audio to the filename specified as the first parameter to the application and continues on to the next priority in the extension. If you hang up the call before pressing the hash key, the audio will not be recorded. For example, the following extension records a sound prompt called **custom-menu** in the **gsm** format in the **en/** sub-directory, and then plays it back to you.
+For creating your own auto-attendant or IVR menus, you're probably going to want to record your own custom prompts. An easy way to do this is with the **Record()** application. The **Record()** application plays a beep, and then begins recording audio until you press the <kbd>#</kbd> key on your keypad. It then saves the audio to the filename specified as the first parameter to the application and continues on to the next priority in the extension. If you hang up the call before pressing the hash key, the audio will not be recorded. For example, the following extension records a sound prompt called **custom-menu** in the **gsm** format in the **en/** sub-directory, and then plays it back to you.
 
 ```javascript title=" " linenums="1"
 exten => 6597,1,Answer(500)

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Using-Menuselect-to-Select-Asterisk-Options.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Using-Menuselect-to-Select-Asterisk-Options.md
@@ -22,13 +22,13 @@ The next step in the build process is to tell Asterisk which [modules](/Fundamen
 Terminal must be at least 80 x 27.  
 ```
 
-The **Menuselect** menu should look like the screen-shot below. On the left-hand side, you have a list of categories, such as **Applications**, **Channel** **Drivers**, and **PBX** **Modules**. On the right-hand side, you'll see a list of modules that correspond with the select category. At the bottom of the screen you'll see two buttons. You can use the **Tab** key to cycle between the various sections, and press the **Enter** key to select or unselect a particular module. If you see **[\*]** next to a module name, it signifies that the module has been selected. If you see **\*XXX** next to a module name, it signifies that the select module cannot be built, as one of its dependencies is missing. In that case, you can look at the bottom of the screen for the line labeled **Depends** **upon**: for a description of the missing dependency.
+The **Menuselect** menu should look like the screen-shot below. On the left-hand side, you have a list of categories, such as **Applications**, **Channel** **Drivers**, and **PBX** **Modules**. On the right-hand side, you'll see a list of modules that correspond with the select category. At the bottom of the screen you'll see two buttons. You can use the **<kbd>Tab</kbd>** key to cycle between the various sections, and press the **<kbd>Enter</kbd>** key to select or unselect a particular module. If you see **[\*]** next to a module name, it signifies that the module has been selected. If you see **\*XXX** next to a module name, it signifies that the select module cannot be built, as one of its dependencies is missing. In that case, you can look at the bottom of the screen for the line labeled **Depends** **upon**: for a description of the missing dependency.
 
 ![](menuselect.png)
 
 When you're first learning your way around Asterisk on a test system, you'll probably want to stick with the default settings in **Menuselect**. If you're building a production system, however, you may not wish to build all of the various modules, and instead only build the modules that your system is using.
 
-When you are finished selecting the modules and options you'd like in **Menuselect**, press **F12** to save and exit, or highlight the **Save** **and** **Exit** button and press enter.
+When you are finished selecting the modules and options you'd like in **Menuselect**, press **<kbd>F12</kbd>** to save and exit, or highlight the **Save** **and** **Exit** button and press enter.
 
 ![](image2993.png)
 

--- a/docs/Operation/Asterisk-Command-Line-Interface/CLI-Syntax-and-Help-Commands.md
+++ b/docs/Operation/Asterisk-Command-Line-Interface/CLI-Syntax-and-Help-Commands.md
@@ -6,7 +6,7 @@ pageid: 28315594
 Command Syntax and Availability
 ===============================
 
-Commands follow a general syntax of **<module name> <action type> <parameters>**.
+Commands follow a general syntax of **`<module name> <action type> <parameters>`**.
 
 For example:
 
@@ -33,7 +33,7 @@ Finding Help at the CLI
 Command-line Completion
 -----------------------
 
-The Asterisk CLI supports command-line completion on all commands, including many arguments. To use it, simply press the **<Tab>** key at any time while entering the beginning of any command. If the command can be completed unambiguously, it will do so, otherwise it will complete as much of the command as possible. Additionally, Asterisk will print a list of all possible matches, if possible.
+The Asterisk CLI supports command-line completion on all commands, including many arguments. To use it, simply press the **<kbd>Tab</kbd>** key at any time while entering the beginning of any command. If the command can be completed unambiguously, it will do so, otherwise it will complete as much of the command as possible. Additionally, Asterisk will print a list of all possible matches, if possible.
 
 On this Page
 

--- a/docs/Test-Suite-Documentation/Using-Python3.md
+++ b/docs/Test-Suite-Documentation/Using-Python3.md
@@ -75,7 +75,7 @@ Install Asterisk
 * Add **`--enable-dev-mode`** and optionally, **`--disable-binary-modules`** to your **`./configure`** command line.  Disabling the binary modules just prevents the need to download the external codecs and res_digium_phone.
 * In menuselect...
 	+ Under **Compiler Flags - Development**,  enable **DONT_OPTIMIZE**, **MALLOC_DEBUG**, **`DO_CRASH`** and **`TEST_FRAMEWORK`** and disable **`COMPILE_DOUBLE`**.
-	+ Make sure all modules are enabled.  You don't need the **Test Modules** though.  If you enter **Test Modules** and press **`F7`**, you can quickly disable all modules.
+	+ Make sure all modules are enabled.  You don't need the **Test Modules** though.  If you enter **Test Modules** and press **<kbd>F7</kbd>**, you can quickly disable all modules.
 * Build and install Asterisk and the development header files.
 
 ```bash title=" " linenums="1"


### PR DESCRIPTION
This will render beautiful keyboard keys when converted to html but will also produce valid text-only output for command line markdown readers.

Additionally one occasion where this also previously wasn't rendered at all (not even as text) due to an incorrect prefix was fixed.