### PR TITLE
Update "make" command argument

### DIFF
--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Building-and-Installing-DAHDI.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Building-and-Installing-DAHDI.md
@@ -44,7 +44,7 @@ Starting with DAHDI-Linux-complete version 2.8.0+2.8.0, all files necessary to i
 
 [root@server dahdi-linux-complete-2.X.Y+2.X.Y]# make install
 
-[root@server dahdi-linux-complete-2.X.Y+2.X.Y]# make config 
+[root@server dahdi-linux-complete-2.X.Y+2.X.Y]# make install-config
 
 ```
 


### PR DESCRIPTION
"config" is not a valid argument for the "make" command when dealing with versions of dahdi-linux-complete older than 2.9.2 (according to makefile), replaced by "install-config" instead.