### PR TITLE
fix: wrong field in odbc conf for db connection

### DIFF
--- a/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Setting-up-PJSIP-Realtime.md
+++ b/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Setting-up-PJSIP-Realtime.md
@@ -164,7 +164,7 @@ Next, we'll tell ODBC **which** MySQL database to use.  To do this, we'll edit t
 [asterisk]
 Driver = MySQL
 Description = MySQL connection to ‘asterisk’ database
-Server = localhost
+Servername = localhost
 Port = 3306
 Database = asterisk
 UserName = root

--- a/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Getting-Asterisk-Connected-to-MySQL-via-ODBC.md
+++ b/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Getting-Asterisk-Connected-to-MySQL-via-ODBC.md
@@ -128,7 +128,7 @@ Add the following to /etc/odbc.ini
 Description = MySQL connection to 'asterisk' database
 Driver = MariaDB
 Database = asterisk
-Server = localhost
+Servername = localhost
 Port = 3306
 Socket = /var/lib/mysql/mysql.sock
 


### PR DESCRIPTION
The current "Server" field is invalid and cannot be used to configure remote database server