### PR TITLE
docs: Don't escape special characters inside code blocks.

### DIFF
--- a/docs/Configuration/Applications/Asterisk-Queues/Building-Queues.md
+++ b/docs/Configuration/Applications/Asterisk-Queues/Building-Queues.md
@@ -50,7 +50,7 @@ What we're doing here is creating a [std-device] template and applying it to a p
 Then our devices can register to Asterisk. In my case I have a hard phone and a soft phone registered. I can verify their connectivity by running 'sip show peers'.
 
 ```
-\*CLI> sip show peers
+*CLI> sip show peers
 Name/username Host Dyn Nat ACL Port Status 
 0004f2040001/0004f2040001 192.168.128.145 D 5060 Unmonitored 
 0004f2040002/0004f2040002 192.168.128.126 D 5060 Unmonitored 
@@ -63,7 +63,7 @@ Name/username Host Dyn Nat ACL Port Status
 Next, we need to configure our system to track the state of the devices. We do this by defining a 'hint' in the dialplan which creates the ability for a device subscription to be retained in memory. By default we can see there are no hints registered in our system by running the 'core show hints' command.
 
 ```
-\*CLI> core show hints
+*CLI> core show hints
 There are no registered dialplan hint
 
 ```
@@ -84,7 +84,7 @@ Then perform a 'dialplan reload' in order to reload the dialplan.
 After reloading our dialplan, you can see the status of the devices with 'core show hints' again.
 
 ```
-\*CLI> core show hints
+*CLI> core show hints
 
  -= Registered Asterisk Dial Plan Hints =-
  0004f2040002@default : SIP/0004f2040002 State:Idle Watchers 0
@@ -110,11 +110,11 @@ exten => 555,1,Playback(tt-monkeys)
 Dial that extension and then check the state of your device on the console.
 
 ```
-\*CLI> == Using SIP RTP CoS mark 5
+*CLI> == Using SIP RTP CoS mark 5
  -- Executing [555@devices:1] Playback("SIP/0004f2040001-00000001", "tt-monkeys") in new stack
  -- <SIP/0004f2040001-00000001> Playing 'tt-monkeys.slin' (language 'en')
 
-\*CLI> core show hints
+*CLI> core show hints
 
  -= Registered Asterisk Dial Plan Hints =-
  0004f2040002@default : SIP/0004f2040002 State:Idle Watchers 0
@@ -149,11 +149,11 @@ callcounter=yes ; <-- add this
 Then reload chan_sip with 'sip reload' and perform our 555 test again. Dial 555 and then check the device state with 'core show hints'.
 
 ```
-\*CLI> == Using SIP RTP CoS mark 5
+*CLI> == Using SIP RTP CoS mark 5
  -- Executing [555@devices:1] Playback("SIP/0004f2040001-00000002", "tt-monkeys") in new stack
  -- <SIP/0004f2040001-00000002> Playing 'tt-monkeys.slin' (language 'en')
 
-\*CLI> core show hints
+*CLI> core show hints
 
  -= Registered Asterisk Dial Plan Hints =-
  0004f2040002@default : SIP/0004f2040002 State:Idle Watchers 0
@@ -207,7 +207,7 @@ ringinuse=no ; don't ring members when already InUse
 After defining our queues, lets reload our app_queue.so module.
 
 ```
-\*CLI> module reload app_queue.so
+*CLI> module reload app_queue.so
  -- Reloading module 'app_queue.so' (True Call Queueing)
 
  == Parsing '/etc/asterisk/queues.conf': == Found
@@ -217,7 +217,7 @@ After defining our queues, lets reload our app_queue.so module.
 Then verify our queues loaded with 'queue show'.
 
 ```
-\*CLI> queue show
+*CLI> queue show
 support has 0 calls (max unlimited) in 'rrmemory' strategy (0s holdtime, 0s talktime), W:0, C:0, A:0, SL:0.0% within 0s
  No Members
  No Callers
@@ -245,7 +245,7 @@ The penalty, membername, and state_interface are all optional values. Special at
 Lets add our device located at SIP/0004f2040001
 
 ```
-\*CLI> queue add member SIP/0004f2040001 to sales
+*CLI> queue add member SIP/0004f2040001 to sales
 Added interface 'SIP/0004f2040001' to queue 'sales'
 
 ```
@@ -253,7 +253,7 @@ Added interface 'SIP/0004f2040001' to queue 'sales'
 Then lets verify our member was indeed added.
 
 ```
-\*CLI> queue show sales
+*CLI> queue show sales
 sales has 0 calls (max unlimited) in 'rrmemory' strategy (0s holdtime, 0s talktime), W:0, C:0, A:0, SL:0.0% within 0s
  Members: 
  SIP/0004f2040001 (dynamic) (Not in use) has taken no calls yet
@@ -264,11 +264,11 @@ sales has 0 calls (max unlimited) in 'rrmemory' strategy (0s holdtime, 0s talkti
 Now, if we dial our 555 extension, we should see that our member becomes InUse within the queue.
 
 ```
-\*CLI> == Using SIP RTP CoS mark 5
+*CLI> == Using SIP RTP CoS mark 5
  -- Executing [555@devices:1] Playback("SIP/0004f2040001-00000001", "tt-monkeys") in new stack
  -- <SIP/0004f2040001-00000001> Playing 'tt-monkeys.slin' (language 'en')
 
-\*CLI> queue show sales
+*CLI> queue show sales
 sales has 0 calls (max unlimited) in 'rrmemory' strategy (0s holdtime, 0s talktime), W:0, C:0, A:0, SL:0.0% within 0s
  Members: 
  SIP/0004f2040001 (dynamic) (In use) has taken no calls yet
@@ -279,7 +279,7 @@ sales has 0 calls (max unlimited) in 'rrmemory' strategy (0s holdtime, 0s talkti
 We can also remove our members from the queue using the 'queue remove' CLI command.
 
 ```
-\*CLI> queue remove member SIP/0004f2040001 from sales 
+*CLI> queue remove member SIP/0004f2040001 from sales 
 Removed interface 'SIP/0004f2040001' from queue 'sales'
 
 ```
@@ -304,14 +304,14 @@ exten => 101,1,Queue(support)
 Then reload the dialplan, and try calling extension 100 from SIP/0004f2040002, which is the device we have not logged into the queue.
 
 ```
-\*CLI> dialplan reload
+*CLI> dialplan reload
 
 ```
 
 And now we call the queue at extension 100 which will ring our device at SIP/0004f2040001.
 
 ```
-\*CLI> == Using SIP RTP CoS mark 5
+*CLI> == Using SIP RTP CoS mark 5
  -- Executing [100@devices:1] Queue("SIP/0004f2040002-00000005", "sales") in new stack
  -- Started music on hold, class 'default', on SIP/0004f2040002-00000005
  == Using SIP RTP CoS mark 5
@@ -322,7 +322,7 @@ And now we call the queue at extension 100 which will ring our device at SIP/000
 We can see the device state has changed to Ringing while the device is ringing.
 
 ```
-\*CLI> queue show sales
+*CLI> queue show sales
 sales has 1 calls (max unlimited) in 'rrmemory' strategy (2s holdtime, 3s talktime), W:0, C:1, A:1, SL:0.0% within 0s
  Members: 
  SIP/0004f2040001 (dynamic) (Ringing) has taken 1 calls (last was 14 secs ago)
@@ -334,7 +334,7 @@ sales has 1 calls (max unlimited) in 'rrmemory' strategy (2s holdtime, 3s talkti
 Our queue member then answers the phone.
 
 ```
-\*CLI> -- SIP/0004f2040001-00000006 answered SIP/0004f2040002-00000005
+*CLI> -- SIP/0004f2040001-00000006 answered SIP/0004f2040002-00000005
  -- Stopped music on hold on SIP/0004f2040002-00000005
  -- Native bridging SIP/0004f2040002-00000005 and SIP/0004f2040001-00000006
 
@@ -343,7 +343,7 @@ Our queue member then answers the phone.
 And we can see the queue member is now in use.
 
 ```
-\*CLI> queue show sales
+*CLI> queue show sales
 sales has 0 calls (max unlimited) in 'rrmemory' strategy (3s holdtime, 3s talktime), W:0, C:1, A:1, SL:0.0% within 0s
  Members: 
  SIP/0004f2040001 (dynamic) (In use) has taken 1 calls (last was 22 secs ago)
@@ -354,14 +354,14 @@ sales has 0 calls (max unlimited) in 'rrmemory' strategy (3s holdtime, 3s talkti
 Then the call is hung up.
 
 ```
-\*CLI> == Spawn extension (devices, 100, 1) exited non-zero on 'SIP/0004f2040002-00000005'
+*CLI> == Spawn extension (devices, 100, 1) exited non-zero on 'SIP/0004f2040002-00000005'
 
 ```
 
 And we see that our queue member is available to take another call.
 
 ```
-\*CLI> queue show sales
+*CLI> queue show sales
 sales has 0 calls (max unlimited) in 'rrmemory' strategy (3s holdtime, 4s talktime), W:0, C:2, A:1, SL:0.0% within 0s
  Members: 
  SIP/0004f2040001 (dynamic) (Not in use) has taken 2 calls (last was 6 secs ago)
@@ -426,9 +426,9 @@ Lets move into the nitty-gritty section and show how we can login and logout our
 First, we create a pattern match that takes star  plus the queue number that we want to login or logout of. So to login/out of the sales queue (100) we would dial \*100. We use the same extension for logging in and out.
 
 ```
-; Extension \*100 or \*101 will login/logout a queue member from sales or support queues respectively.
-exten => _\*10[0-1],1,Set(xtn=${EXTEN:1}) ; save ${EXTEN} with \* chopped off to ${xtn}
-exten => _\*10[0-1],n,Goto(queueLoginLogout,member_check,1) ; check if already logged into a queue
+; Extension *100 or *101 will login/logout a queue member from sales or support queues respectively.
+exten => _*10[0-1],1,Set(xtn=${EXTEN:1}) ; save ${EXTEN} with * chopped off to ${xtn}
+exten => _*10[0-1],n,Goto(queueLoginLogout,member_check,1) ; check if already logged into a queue
 
 ```
 
@@ -537,7 +537,7 @@ And that's it! Give it a shot and you should see console output similar to the f
 You can see there are already a couple of queue members logged into the sales queue.
 
 ```
-\*CLI> queue show sales
+*CLI> queue show sales
 sales has 0 calls (max unlimited) in 'rrmemory' strategy (3s holdtime, 4s talktime), W:0, C:2, A:1, SL:0.0% within 0s
  Members: 
  SIP/0004f2040001 (dynamic) (Not in use) has taken no calls yet
@@ -549,9 +549,9 @@ sales has 0 calls (max unlimited) in 'rrmemory' strategy (3s holdtime, 4s talkti
 Then we dial \*100 to logout the active device from the sales queue.
 
 ```
-\*CLI> == Using SIP RTP CoS mark 5
- -- Executing [\*100@devices:1] Set("SIP/0004f2040001-00000012", "xtn=100") in new stack
- -- Executing [\*100@devices:2] Goto("SIP/0004f2040001-00000012", "queueLoginLogout,member_check,1") in new stack
+*CLI> == Using SIP RTP CoS mark 5
+ -- Executing [*100@devices:1] Set("SIP/0004f2040001-00000012", "xtn=100") in new stack
+ -- Executing [*100@devices:2] Goto("SIP/0004f2040001-00000012", "queueLoginLogout,member_check,1") in new stack
  -- Goto (queueLoginLogout,member_check,1)
  -- Executing [member_check@queueLoginLogout:1] Verbose("SIP/0004f2040001-00000012", "2,Logging queue member in or out of the request queue") in new stack
  == Logging queue member in or out of the request queue
@@ -585,7 +585,7 @@ Then we dial \*100 to logout the active device from the sales queue.
 And we can see that the device we loggd out by running 'queue show sales'.
 
 ```
-\*CLI> queue show sales
+*CLI> queue show sales
 sales has 0 calls (max unlimited) in 'rrmemory' strategy (3s holdtime, 4s talktime), W:0, C:2, A:1, SL:0.0% within 0s
  Members: 
  SIP/0004f2040002 (dynamic) (Not in use) has taken no calls yet
@@ -600,7 +600,7 @@ Once we have our queue members logged in, it is inevitable that they will want t
 We have two devices logged into the sales queue as we can see with the 'queue show sales' CLI command.
 
 ```
-\*CLI> queue show sales
+*CLI> queue show sales
 sales has 0 calls (max unlimited) in 'rrmemory' strategy (0s holdtime, 0s talktime), W:0, C:0, A:0, SL:0.0% within 0s
  Members: 
  SIP/0004f2040002 (dynamic) (Not in use) has taken no calls yet
@@ -622,7 +622,7 @@ Usage: queue {pause|unpause} member <member> [queue <queue> [reason <reason>]]
 Lets pause device 0004f2040001 in the sales queue by executing the following.
 
 ```
-\*CLI> queue pause member SIP/0004f2040001 queue sales
+*CLI> queue pause member SIP/0004f2040001 queue sales
 paused interface 'SIP/0004f2040001' in queue 'sales' for reason 'lunch'
 
 ```
@@ -630,7 +630,7 @@ paused interface 'SIP/0004f2040001' in queue 'sales' for reason 'lunch'
 And we can see they are paused with 'queue show sales'.
 
 ```
-\*CLI> queue show sales
+*CLI> queue show sales
 sales has 0 calls (max unlimited) in 'rrmemory' strategy (0s holdtime, 0s talktime), W:0, C:0, A:0, SL:0.0% within 0s
  Members: 
  SIP/0004f2040002 (dynamic) (Not in use) has taken no calls yet
@@ -642,7 +642,7 @@ sales has 0 calls (max unlimited) in 'rrmemory' strategy (0s holdtime, 0s talkti
 At this point the queue member will no longer receive calls from the system. We can unpause them with the CLI command 'queue unpause member'.
 
 ```
-\*CLI> queue unpause member SIP/0004f2040001 queue sales 
+*CLI> queue unpause member SIP/0004f2040001 queue sales 
 unpaused interface 'SIP/0004f2040001' in queue 'sales'
 
 ```
@@ -650,7 +650,7 @@ unpaused interface 'SIP/0004f2040001' in queue 'sales'
 And if you don't specify a queue, it will pause or unpause from all queues.
 
 ```
-\*CLI> queue pause member SIP/0004f2040001
+*CLI> queue pause member SIP/0004f2040001
 paused interface 'SIP/0004f2040001'
 
 ```
@@ -667,11 +667,11 @@ extensions.conf
 
 ; Allow queue members to pause and unpause themselves from all queues, or an individual queue.
 ;
-; _\*0[01]! pattern match will match on \*00 and \*01 plus 0 or more digits.
-exten => _\*0[01]!,1,Verbose(2,Pausing or unpausing queue member from one or more queues)
-exten => _\*0[01]!,n,Set(xtn=${EXTEN:3}) ; save the queue extension to 'xtn'
-exten => _\*0[01]!,n,Set(thisQueue=${GLOBAL(QUEUE_${xtn})}) ; get the queue name if available
-exten => _\*0[01]!,n,GotoIf($[${ISNULL(${thisQueue})} & ${EXISTS(${xtn})}]?invalid_queue,1) ; if 'thisQueue' is blank and the
+; _*0[01]! pattern match will match on *00 and *01 plus 0 or more digits.
+exten => _*0[01]!,1,Verbose(2,Pausing or unpausing queue member from one or more queues)
+exten => _*0[01]!,n,Set(xtn=${EXTEN:3}) ; save the queue extension to 'xtn'
+exten => _*0[01]!,n,Set(thisQueue=${GLOBAL(QUEUE_${xtn})}) ; get the queue name if available
+exten => _*0[01]!,n,GotoIf($[${ISNULL(${thisQueue})} & ${EXISTS(${xtn})}]?invalid_queue,1) ; if 'thisQueue' is blank and the
  ; the agent dialed a queue exten,
  ; we will tell them it's invalid
 
@@ -690,15 +690,15 @@ offset ^ ^ length
 Which causes the following.
 
 ```
- \*00100
+ *00100
  ^^ offset these characters
 
- \*00100
+ *00100
  ^ then return a digit length of one, which is digit 0
 
 ```
 ```
-exten => _\*0[01]!,n,GotoIf($[${EXTEN:2:1} = 0]?pause,1:unpause,1) ; determine if they wanted to pause
+exten => _*0[01]!,n,GotoIf($[${EXTEN:2:1} = 0]?pause,1:unpause,1) ; determine if they wanted to pause
  ; or to unpause.
 
 ```

--- a/docs/Configuration/Applications/Conferencing-Applications/ConfBridge/ConfBridge-CLI-Commands.md
+++ b/docs/Configuration/Applications/Conferencing-Applications/ConfBridge/ConfBridge-CLI-Commands.md
@@ -14,7 +14,7 @@ confbridge kick <conference> <channel>
 Removes the specified channel from the conference, e.g.:
 
 ```
-\*CLI> confbridge kick 1111 SIP/mypeer-00000000
+*CLI> confbridge kick 1111 SIP/mypeer-00000000
 Kicking SIP/mypeer-00000000 from confbridge 1111
 
 ```
@@ -25,7 +25,7 @@ On This Pageconfbridge list
 Shows a summary listing of all bridges, e.g.:
 
 ```
-\*CLI> confbridge list
+*CLI> confbridge list
 Conference Bridge Name Users Marked Locked?
 ================================ ====== ====== ========
 1111 1 0 unlocked
@@ -38,7 +38,7 @@ confbridge list <conference>
 Shows a detailed listing of participants in a specified conference, e.g.:
 
 ```
-\*CLI> confbridge list 1111
+*CLI> confbridge list 1111
 Channel User Profile Bridge Profile Menu
 ============================= ================ ================ ================
 SIP/mypeer-00000001 default_user 1111 sample_user_menu 
@@ -51,7 +51,7 @@ confbridge lock <conference>
 Locks a specified conference so that only Admin users can join, e.g.:
 
 ```
-\*CLI> confbridge lock 1111
+*CLI> confbridge lock 1111
 Conference 1111 is locked.
 
 ```
@@ -62,7 +62,7 @@ confbridge unlock <conference>
 Unlocks a specified conference so that only Admin users can join, e.g.:
 
 ```
-\*CLI> confbridge unlock 1111
+*CLI> confbridge unlock 1111
 Conference 1111 is unlocked.
 
 ```
@@ -73,7 +73,7 @@ confbridge mute <conference> <channel>
 Mutes a specified user in a specified conference, e.g.:
 
 ```
-\*CLI> confbridge mute 1111 SIP/mypeer-00000001
+*CLI> confbridge mute 1111 SIP/mypeer-00000001
 Muting SIP/mypeer-00000001 from confbridge 1111
 
 ```
@@ -84,7 +84,7 @@ confbridge unmute <conference> <channel>
 Unmutes a specified user in a specified conference, e.g.:
 
 ```
-\*CLI> confbridge unmute 1111 SIP/mypeer-00000001
+*CLI> confbridge unmute 1111 SIP/mypeer-00000001
 Unmuting SIP/mypeer-00000001 from confbridge 1111
 
 ```
@@ -95,9 +95,9 @@ confbridge record start <conference> <file>
 Begins recording a conference. If "file" is specified, it will be used, otherwise, the Bridge Profile record_file will be used. If the Bridge Profile does not specify a record_file, one will be automatically generated in Asterisk's monitor directory. Usage:
 
 ```
-\*CLI> confbridge record start 1111
+*CLI> confbridge record start 1111
 Recording started
-\*CLI> == Begin MixMonitor Recording ConfBridgeRecorder/conf-1111-uid-618880445
+*CLI> == Begin MixMonitor Recording ConfBridgeRecorder/conf-1111-uid-618880445
 
 ```
 
@@ -107,9 +107,9 @@ confbridge record stop <confererence>
 Stops recording the specified conference, e.g.:
 
 ```
-\*CLI> confbridge record stop 1111
+*CLI> confbridge record stop 1111
 Recording stopped.
-\*CLI> == MixMonitor close filestream (mixed)
+*CLI> == MixMonitor close filestream (mixed)
  == End MixMonitor Recording ConfBridgeRecorder/conf-1111-uid-618880445
 
 ```
@@ -120,7 +120,7 @@ confbridge show menus
 Shows a listing of Conference Menus as defined in confbridge.conf, e.g.:
 
 ```
-\*CLI> confbridge show menus
+*CLI> confbridge show menus
 --------- Menus -----------
 sample_admin_menu
 sample_user_menu
@@ -133,17 +133,17 @@ confbridge show menu <menu name>
 Shows a detailed listing of a named Conference Menu, e.g.:
 
 ```
-\*CLI> confbridge show menu sample_admin_menu
+*CLI> confbridge show menu sample_admin_menu
 Name: sample_admin_menu
-\*9=increase_talking_volume
-\*8=no_op
-\*7=decrease_talking_volume
-\*6=increase_listening_volume
-\*4=decrease_listening_volume
-\*3=admin_kick_last
-\*2=admin_toggle_conference_lock
-\*1=toggle_mute
-\*=playback_and_continue(conf-adminmenu)
+*9=increase_talking_volume
+*8=no_op
+*7=decrease_talking_volume
+*6=increase_listening_volume
+*4=decrease_listening_volume
+*3=admin_kick_last
+*2=admin_toggle_conference_lock
+*1=toggle_mute
+*=playback_and_continue(conf-adminmenu)
 
 ```
 
@@ -153,7 +153,7 @@ confbridge show profile bridges
 Shows a listing of Bridge Profiles as defined in confbridge.conf, e.g.:
 
 ```
-\*CLI> confbridge show profile bridges
+*CLI> confbridge show profile bridges
 --------- Bridge Profiles -----------
 1111
 default_bridge
@@ -166,7 +166,7 @@ confbridge show profile bridge <bridge>
 Shows a detailed listing of a named Bridge Profile, e.g.:
 
 ```
-\*CLI> confbridge show profile bridge 1111 
+*CLI> confbridge show profile bridge 1111 
 --------------------------------------------
 Name: 1111
 Internal Sample Rate: 16000
@@ -199,7 +199,7 @@ confbridge show profile users
 Shows a listing of User Profiles as defined in confbridge.conf, e.g.:
 
 ```
-\*CLI> confbridge show profile users
+*CLI> confbridge show profile users
 --------- User Profiles -----------
 awesomeusers
 default_user
@@ -212,7 +212,7 @@ confbirdge show profile user <user>
 Shows a detailed listing of a named Bridge Profile, e.g.:
 
 ```
-\*CLI> confbridge show profile user default_user 
+*CLI> confbridge show profile user default_user 
 --------------------------------------------
 Name: default_user
 Admin: false

--- a/docs/Configuration/Channel-Drivers/Local-Channel/Local-Channel-Examples/Using-Callfiles-and-Local-Channels.md
+++ b/docs/Configuration/Channel-Drivers/Local-Channel/Local-Channel-Examples/Using-Callfiles-and-Local-Channels.md
@@ -23,7 +23,7 @@ Our dialplan will perform a lookup in the AstDB to determine which device to cal
 Before looking at our dialplan, lets put some data into AstDB that we can then lookup from the dialplan. From the Asterisk CLI, run the following command:
 
 ```
-\*CLI> database put phones 201/device SIP/0004f2040001 
+*CLI> database put phones 201/device SIP/0004f2040001 
 
 ```
 
@@ -32,7 +32,7 @@ We've now put the device destination (SIP/0004f2040001) into the 201/device key 
 We can then verify our entry in the database using the 'database show' CLI command:
 
 ```
-\*CLI> database show /phones/201/device : SIP/0004f2040001 
+*CLI> database show /phones/201/device : SIP/0004f2040001 
 
 ```
 
@@ -52,7 +52,7 @@ exten => 201,n(hangup),Hangup()
 Then, we can perform a call to our device using the callfile by moving it into the /var/spool/asterisk/outgoing/ directory.
 
 ```
-mv callfile.new /var/spool/asterisks/outgoing\*
+mv callfile.new /var/spool/asterisks/outgoing*
 
 ```
 
@@ -90,7 +90,7 @@ We perform a check to make sure ${DEVICE} isn't NULL. If it is, we'll just hangu
 Now we call our device SIP/0004f2040001 from the Local channel.
 
 ```
-SIP/0004f2040001-00000022 answered Local/201@devices-ecf0;2\*
+SIP/0004f2040001-00000022 answered Local/201@devices-ecf0;2*
 
 ```
 

--- a/docs/Configuration/Channel-Drivers/SIP/Configuring-chan_sip/Configuring-chan_sip-for-Presence-Subscriptions.md
+++ b/docs/Configuration/Channel-Drivers/SIP/Configuring-chan_sip/Configuring-chan_sip-for-Presence-Subscriptions.md
@@ -82,7 +82,7 @@ Notice that we put it in the context we set in **subscribecontext** in sip.conf 
 If you have restarted Asterisk to load the hints, then you can check to make sure they are configured with "core show hints"
 
 ```
-\*CLI> core show hints
+*CLI> core show hints
  -= Registered Asterisk Dial Plan Hints =-
  6001@default : SIP/Bob-mobile&SIP/B State:Unavailable Watchers 0
 
@@ -263,7 +263,7 @@ Content-Length: 0
 Once the subscription has taken place, there is a command to list them. "sip show subscriptions"
 
 ```
-\*CLI> sip show subscriptions
+*CLI> sip show subscriptions
 Peer User Call ID Extension Last state Type Mailbox Expiry
 10.24.17.254 Alice ZjE2ZDAwYThiOTA 6001@default Unavailable pidf+xml <none> 001800
 1 active SIP subscription

--- a/docs/Configuration/Core-Configuration/Configuring-Localized-Tone-Indications.md
+++ b/docs/Configuration/Core-Configuration/Configuring-Localized-Tone-Indications.md
@@ -47,15 +47,15 @@ Explanation of the 'tonelist' usage:
 ; The tonelist itself is defined by a comma-separated sequence of elements.
 ; Each element consist of a frequency (f) with an optional duration (in ms)
 ; attached to it (f/duration). The frequency component may be a mixture of two
-; frequencies (f1+f2) or a frequency modulated by another frequency (f1\*f2).
+; frequencies (f1+f2) or a frequency modulated by another frequency (f1*f2).
 ; The implicit modulation depth is fixed at 90%, though.
 ; If the list element starts with a !, that element is NOT repeated,
 ; therefore, only if all elements start with !, the tonelist is time-limited,
 ; all others will repeat indefinitely.
 ;
 ; concisely:
-; element = [!]freq[+|\*freq2][/duration]
-; tonelist = element[,element]\*
+; element = [!]freq[+|*freq2][/duration]
+; tonelist = element[,element]*
 
 ```
 

--- a/docs/Configuration/Core-Configuration/Logging-Configuration.md
+++ b/docs/Configuration/Core-Configuration/Logging-Configuration.md
@@ -98,15 +98,15 @@ Log Files Section:
 ; not be logged to the file. If a verbose level is not given, verbose messages are logged
 ; based upon the current level set for the root console.
 ;
-; The special character "\*" can also be specified and represents all levels, even dynamic
+; The special character "*" can also be specified and represents all levels, even dynamic
 ; levels registered by modules after the logger has been initialized. This means that loading
 ; and unloading modules that create and remove dynamic logging levels will result in these
-; levels being included on filenames that have a level name of "\*", without any need to
+; levels being included on filenames that have a level name of "*", without any need to
 ; perform a "logger reload" or similar operation.
 ;
-; Note, there is no value in specifying both "\*" and specific level types for a file name.
-; The "\*" level means ALL levels. The only exception is if you need to specify a specific
-; verbose level. e.g, "verbose(3),\*".
+; Note, there is no value in specifying both "*" and specific level types for a file name.
+; The "*" level means ALL levels. The only exception is if you need to specify a specific
+; verbose level. e.g, "verbose(3),*".
 ;
 ; It is highly recommended that you DO NOT turn on debug mode when running a production system
 ; unless you are in the process of debugging a specific issue. Debug mode outputs a LOT of

--- a/docs/Configuration/Dialplan/Asterisk-Extension-Language-AEL/AEL-Example-Usages/AEL-Conditionals.md
+++ b/docs/Configuration/Dialplan/Asterisk-Extension-Language-AEL/AEL-Example-Usages/AEL-Conditionals.md
@@ -16,7 +16,7 @@ context conditional {
  }
  else 
  Voicemail(${EXTEN},u);
- ifTime (14:00-23:59|sat-sun|\*|\*) 
+ ifTime (14:00-23:59|sat-sun|*|*) 
  Voicemail(${EXTEN},b); 
  else 
  { 

--- a/docs/Configuration/Dialplan/Conditional-Applications.md
+++ b/docs/Configuration/Dialplan/Conditional-Applications.md
@@ -24,7 +24,7 @@ Example of use :
 ```
 exten => s,2,Set(vara=1)
 exten => s,3,Set(varb=$[${vara} + 2])
-exten => s,4,Set(varc=$[${varb} \* 2])
+exten => s,4,Set(varc=$[${varb} * 2])
 exten => s,5,GotoIf($[${varc} = 6]?99,1:s,6)
 
 ```

--- a/docs/Configuration/Dialplan/Expressions/index.md
+++ b/docs/Configuration/Dialplan/Expressions/index.md
@@ -9,7 +9,7 @@ For example, after the sequence:
 
 ```
 exten => 1,1,Set(lala=$[1 + 2])
-exten => 1,2,Set(koko=$[2 \* ${lala}])
+exten => 1,2,Set(koko=$[2 * ${lala}])
 
 ```
 

--- a/docs/Configuration/Dialplan/Lua-Dialplan-Configuration/index.md
+++ b/docs/Configuration/Dialplan/Lua-Dialplan-Configuration/index.md
@@ -39,7 +39,7 @@ extensions = {
 The `extensions.lua` file can be reloaded by reloading the pbx_lua module.
 
 ```
-\*CLI> module reload pbx_lua
+*CLI> module reload pbx_lua
 
 ```
 

--- a/docs/Configuration/Features/Built-in-Dynamic-Features.md
+++ b/docs/Configuration/Features/Built-in-Dynamic-Features.md
@@ -26,7 +26,7 @@ same => n,Hangup()
 Set the DTMF sequence for attended transfer on this channel to \*9.  
 
 ```
-exten => s,1,Set(FEATUREMAP(atxfer)=\*9)
+exten => s,1,Set(FEATUREMAP(atxfer)=*9)
 same => n,Dial(SIP/100,,T)
 same => n,Hangup()
 

--- a/docs/Configuration/Features/Call-Pickup.md
+++ b/docs/Configuration/Features/Call-Pickup.md
@@ -102,7 +102,7 @@ Calls picked up using pickupexten can hear an optional sound file for success an
 features.conf  
 
 ```
-pickupexten = \*8 ; Configure the pickup extension. (default is \*8)
+pickupexten = *8 ; Configure the pickup extension. (default is *8)
 pickupsound = beep ; to indicate a successful pickup (default: no sound)
 pickupfailsound = beeperr ; to indicate that the pickup failed (default: no sound)
 

--- a/docs/Configuration/Features/Feature-Code-Call-Transfers.md
+++ b/docs/Configuration/Features/Feature-Code-Call-Transfers.md
@@ -47,7 +47,7 @@ In features.conf you must configure the blindxfer or atxfer options in the featu
 ```
 [featuremap]
 blindxfer = #1
-atxfer = \*2
+atxfer = *2
 
 ```
 
@@ -97,10 +97,10 @@ Dialing the **atxferswap** code swaps you between bridges with either party befo
 
 ```
 [general]
-atxferabort = \*3
-atxfercomplete = \*4
-atxferthreeway = \*5
-atxferswap = \*6
+atxferabort = *3
+atxfercomplete = *4
+atxferthreeway = *5
+atxferswap = *6
 
 ```
 

--- a/docs/Configuration/Features/One-Touch-Features.md
+++ b/docs/Configuration/Features/One-Touch-Features.md
@@ -33,9 +33,9 @@ features.conf
 
 ```
  [featuremap]
-automon = \*1
-automixmon = \*3
-disconnect = \*0
+automon = *1
+automixmon = *3
+disconnect = *0
 parkcall = #72
 
 ```

--- a/docs/Configuration/Interfaces/Asterisk-Calendaring/Configuring-Asterisk-Calendaring.md
+++ b/docs/Configuration/Interfaces/Asterisk-Calendaring/Configuring-Asterisk-Calendaring.md
@@ -97,14 +97,14 @@ timeframe = 60
 Once you have a configuration you can startup Asterisk or else reload the modules. After this you can check to see if the calendar is being read. Use the commands **"calendar show calendars"** and **"calendar show calendar <calendar name>"**
 
 ```
-CentOSLab\*CLI> calendar show calendars
+CentOSLab*CLI> calendar show calendars
 Calendar Type Status
 -------- ---- ------
 gcal1 ical busy
 
 ```
 ```
-CentOSLab\*CLI> calendar show calendar gcal1
+CentOSLab*CLI> calendar show calendar gcal1
 Name : gcal1
 Notify channel :
 Notify context :

--- a/docs/Configuration/Interfaces/Asterisk-Calendaring/index.md
+++ b/docs/Configuration/Interfaces/Asterisk-Calendaring/index.md
@@ -19,7 +19,7 @@ All four modules support event notification. Both CalDAV and Exchange support re
 You can see list all registered calendar types at the CLI with **"****calendar show types"**.
 
 ```
-\*CLI> calendar show types
+*CLI> calendar show types
 Type Description
 caldav CalDAV calendars
 exchange MS Exchange calendars

--- a/docs/Configuration/Interfaces/Asterisk-Manager-Interface-AMI/AMI-v2-Specification/index.md
+++ b/docs/Configuration/Interfaces/Asterisk-Manager-Interface-AMI/AMI-v2-Specification/index.md
@@ -112,8 +112,8 @@ Exten: s
 Priority: 1
 CallerID: "Kermit the Frog" <123-4567>
 Account: FrogLegs
-Variable: MY\_VAR=frogs
-Variable: HIDE\_FROM\_CHEF=true
+Variable: MY_VAR=frogs
+Variable: HIDE_FROM_CHEF=true
 ```
 
 In addition, no ordering is implied on message specific keys. Hence, the following two messages are semantically the same.
@@ -127,15 +127,15 @@ Exten: s
 Priority: 1
 CallerID: "Kermit the Frog" <123-4567>
 Account: FrogLegs
-Variable: MY\_VAR=frogs
-Variable: HIDE\_FROM\_CHEF=true50%ActionId: SDY4-12837-123878782
+Variable: MY_VAR=frogs
+Variable: HIDE_FROM_CHEF=true50%ActionId: SDY4-12837-123878782
 ```
 
 ```
 Action: Originate
 ActionId: SDY4-12837-123878782
-Variable: HIDE\_FROM\_CHEF=true
-Variable: MY\_VAR=frogs
+Variable: HIDE_FROM_CHEF=true
+Variable: MY_VAR=frogs
 Channel: PJSIP/kermit-00000002
 Account: FrogLegs
 Context: outbound
@@ -585,13 +585,13 @@ Example - Two Party Bridge:
 ```
 Event: BridgeCreate
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeUniqueid: 1234
 BridgeNumChannels: 0
 ...
 Event: BridgeEnter
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeUniqueid: 1234
 BridgeNumChannels: 1
 Channel: PJSIP/kermit-00000001
@@ -603,7 +603,7 @@ Kermit the Frog's PJSIP channel enters into Bridge 1234. As a result, the bridge
 ```
 Event: BridgeEnter
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeUniqueid: 1234
 BridgeNumChannels: 2
 Channel: PJSIP/gonzo-00000002
@@ -615,7 +615,7 @@ Gonzo the Great enters the bridge and talks with Kermit. Note that the bridge Go
 ```
 Event: BridgeLeave
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeUniqueid: 1234
 BridgeNumChannels: 1
 Channel: PJSIP/kermit-00000001
@@ -631,7 +631,7 @@ Kermit realizes that he has to leave to avoid Miss Piggy, so he hangs up on Gonz
 ```
 Event: BridgeLeave
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeUniqueid: 1234
 BridgeNumChannels: 0
 Channel: PJSIP/gonzo-00000002
@@ -643,7 +643,7 @@ Uniqueid: asterisk-1368479150.1
 ...
 Event: BridgeDestroy
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeUniqueid: 1234
 BridgeNumChannels: 0
 ```
@@ -667,12 +667,12 @@ Example - Blind Transfer
 ```
 Event: BridgeCreate
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeUniqueid: 1234
 ...
 Event: BridgeEnter
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeUniqueid: 1234
 Channel: PJSIP/kermit-00000001
 Uniqueid: asterisk-1368479150.0
@@ -683,7 +683,7 @@ Kermit the Frog's PJSIP channel enters into Bridge 1234
 ```
 Event: BridgeEnter
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeUniqueid: 1234
 Channel: PJSIP/fozzie-00000002
 Uniqueid: asterisk-1368479150.2
@@ -736,7 +736,7 @@ TransfererChannel: PJSIP/fozzie-00000002
 TransfererUniqueid: asterisk-1368479150.2
 BridgeUniqueid: 1234
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 Context: default
 Extension: 2000
 ```
@@ -761,7 +761,7 @@ Uniqueid: asterisk-1368479150.0
 Event: BridgeLeave
 BridgeUniqueid: 1234
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 Channel: PJSIP/kermit-00000001
 Uniqueid: asterisk-1368479150.0
 ```
@@ -772,14 +772,14 @@ Kermit leaves the bridge with Fozzie. Asterisk politely turns off the hold music
 Event: BridgeLeave
 BridgeUniqueid: 1234
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 Channel: PJSIP/fozzie-00000002
 Uniqueid: asterisk-1368479150.2
 ...
 Event: BridgeDestroy
 BridgeUniqueid: 1234
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 ```
 
 Because Fozzie isn't talking to anyone anymore, he leaves the bridge as well. At this point Asterisk could hang up Fozzie's channel, or, if configured, he could continue on in the dialplan (say, perhaps, to talk to his rubber chicken).
@@ -845,13 +845,13 @@ DialStatus: ANSWER
 Event: BridgeCreate
 BridgeUniqueid: 1234
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeNumChannels: 0
 ...
 Event: BridgeEnter
 BridgeUniqueid: 1234
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeNumChannels: 1
 Channel: PJSIP/gonzo-00000001
 Uniqueid: asterisk-1368479150.0
@@ -859,7 +859,7 @@ Uniqueid: asterisk-1368479150.0
 Event: BridgeEnter
 BridgeUniqueid: 1234
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeNumChannels: 2
 Channel: Local/kermit@default-00000001;1
 Uniqueid: asterisk-1368479150.1
@@ -891,13 +891,13 @@ DialStatus: ANSWER
 Event: BridgeCreate
 BridgeUniqueid: 5678
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeNumChannels: 0
 ...
 Event: BridgeEnter
 BridgeUniqueid: 5678
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeNumChannels: 1
 Channel: Local/kermit@default-00000001;2
 Uniqueid: asterisk-1368479150.2
@@ -905,7 +905,7 @@ Uniqueid: asterisk-1368479150.2
 Event: BridgeEnter
 BridgeUniqueid: 5678
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeNumChannels: 2
 Channel: PJSIP/kermit-00000002
 Uniqueid: asterisk-1368479150.3
@@ -927,7 +927,7 @@ SourceUniqueid: asterisk-1368479150.0
 Event: BridgeLeave
 BridgeUniqueid: 1234
 BridgeType: basic
-BridgeTechnology: simple\_bridge
+BridgeTechnology: simple_bridge
 BridgeNumChannels: 1
 Channel: PJSIP/gonzo-00000001
 Uniqueid: asterisk-1368479150.0
@@ -935,7 +935,7 @@ Uniqueid: asterisk-1368479150.0
 Event: BridgeEnter 
 BridgeUniqueid: 5678
 BridgeType: basic 
-BridgeTechnology: simple\_bridge 
+BridgeTechnology: simple_bridge 
 BridgeNumChannels: 3 
 Channel: PJSIP/gonzo-00000001
 Uniqueid: asterisk-1368479150.0
@@ -947,7 +947,7 @@ Asterisk determines that it can optimize away the Local channel. It notifies the
 Event: BridgeLeave
 BridgeUniqueid: 5678
 BridgeType: basic 
-BridgeTechnology: simple\_bridge 
+BridgeTechnology: simple_bridge 
 BridgeNumChannels: 2 
 Channel: Local/kermit@default-00000001;2
 Uniqueid: asterisk-1368479150.2
@@ -955,13 +955,13 @@ Uniqueid: asterisk-1368479150.2
 Event: LocalOptimizationEnd 
 LocalOneChannel: Local/kermit@default-00000001;1
 LocalOneUniqueid: asterisk-1368479150.1
-LocalTwoChannel: Local/dial\_bar@default-00000001;2 
+LocalTwoChannel: Local/dial_bar@default-00000001;2 
 LocalTwoUniqueid: asterisk-1368479150.2
 ...
 Event: BridgeLeave
 BridgeUniqueid: 1234
 BridgeType: basic 
-BridgeTechnology: simple\_bridge 
+BridgeTechnology: simple_bridge 
 BridgeNumChannels: 0
 Channel: Local/kermit@default-00000001;1
 Uniqueid: asterisk-1368479150.1
@@ -977,7 +977,7 @@ Uniqueid: asterisk-1368479150.2
 Event: BridgeDestroy
 BridgeUniqueid: 1234
 BridgeType: basic 
-BridgeTechnology: simple\_bridge 
+BridgeTechnology: simple_bridge 
 BridgeNumChannels: 0
 ```
 

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/ARI-and-Bridges-Basic-Mixing-Bridges.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/ARI-and-Bridges-Basic-Mixing-Bridges.md
@@ -95,8 +95,8 @@ def stasis_start_cb(channel_obj, ev):
 		channel.hangup()
 		return
 
-	channel.on_event('StasisEnd', lambda \*args: safe_hangup(outgoing))
-	outgoing.on_event('StasisEnd', lambda \*args: safe_hangup(channel))
+	channel.on_event('StasisEnd', lambda *args: safe_hangup(outgoing))
+	outgoing.on_event('StasisEnd', lambda *args: safe_hangup(channel))
 ```
 
 The `safe_hangup` function referenced above simply does a "safe" hangup on the channel provided. This is because it is entirely possible for both parties to hang up nearly simultaneously. Since our Python code is running in a separate process from Asterisk, we may be processing the hang up of the first party and instruct Asterisk to hang up the second party when they are already technically hung up! Again, it is always a good idea to view the processing of a communications application in an asynchronous fashion: we live in an asynchronous world, and a user can take an action at any moment in time.
@@ -135,8 +135,8 @@ def outgoing_start_cb(channel_obj, ev):
 	bridge.addChannel(channel=[channel.id, outgoing.id])
 
 	# Clean up the bridge when done
-	channel.on_event('StasisEnd', lambda \*args: safe_bridge_destroy(bridge))
-	outgoing.on_event('StasisEnd', lambda \*args: safe_bridge_destroy(bridge))
+	channel.on_event('StasisEnd', lambda *args: safe_bridge_destroy(bridge))
+	outgoing.on_event('StasisEnd', lambda *args: safe_bridge_destroy(bridge))
 
 outgoing.on_event('StasisStart', outgoing_start_cb)
 ```
@@ -207,8 +207,8 @@ def stasis_start_cb(channel_obj, ev):
 		channel.hangup()
 		return
 
-	channel.on_event('StasisEnd', lambda \*args: safe_hangup(outgoing))
-	outgoing.on_event('StasisEnd', lambda \*args: safe_hangup(channel))
+	channel.on_event('StasisEnd', lambda *args: safe_hangup(outgoing))
+	outgoing.on_event('StasisEnd', lambda *args: safe_hangup(channel))
 
  def outgoing_start_cb(channel_obj, ev):
 	"""StasisStart handler for our dialed channel"""
@@ -221,8 +221,8 @@ def stasis_start_cb(channel_obj, ev):
 	bridge.addChannel(channel=[channel.id, outgoing.id])
 
 	# Clean up the bridge when done
-	channel.on_event('StasisEnd', lambda \*args: safe_bridge_destroy(bridge))
-	outgoing.on_event('StasisEnd', lambda \*args: safe_bridge_destroy(bridge))
+	channel.on_event('StasisEnd', lambda *args: safe_bridge_destroy(bridge))
+	outgoing.on_event('StasisEnd', lambda *args: safe_bridge_destroy(bridge))
 	outgoing.on_event('StasisStart', outgoing_start_cb)
 
 client.on_channel_event('StasisStart', stasis_start_cb)

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/ARI-and-Bridges-Bridge-Operations.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/ARI-and-Bridges-Bridge-Operations.md
@@ -183,8 +183,8 @@ def stasis_start_cb(channel_obj, ev):
  channel.hangup()
  return
 
- channel.on_event('StasisEnd', lambda \*args: safe_hangup(outgoing))
- outgoing.on_event('StasisEnd', lambda \*args: safe_hangup(channel))
+ channel.on_event('StasisEnd', lambda *args: safe_hangup(outgoing))
+ outgoing.on_event('StasisEnd', lambda *args: safe_hangup(channel))
 
  def outgoing_start_cb(channel_obj, ev):
  """StasisStart handler for our dialed channel"""
@@ -199,9 +199,9 @@ def stasis_start_cb(channel_obj, ev):
  bridge.addChannel(channel=[channel.id, outgoing.id])
 
  # Clean up the bridge when done
- channel.on_event('StasisEnd', lambda \*args:
+ channel.on_event('StasisEnd', lambda *args:
  safe_bridge_destroy(bridge))
- outgoing.on_event('StasisEnd', lambda \*args:
+ outgoing.on_event('StasisEnd', lambda *args:
  safe_bridge_destroy(bridge))
 
  outgoing.on_event('StasisStart', outgoing_start_cb)

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Channels/ARI-and-Channels-Handling-DTMF.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Channels/ARI-and-Channels-Handling-DTMF.md
@@ -665,7 +665,7 @@ function queueUpSound() {
  if (!state.done) {
  // have we played all sounds in the menu?
  if (!state.currentSound) {
- var timer = setTimeout(stillThere, 10 \* 1000);
+ var timer = setTimeout(stillThere, 10 * 1000);
  timers[channel.id] = timer;
  } else {
  var playback = client.Playback();
@@ -888,7 +888,7 @@ function clientLoaded (err, client) {
  }
  }
 
- /*\*
+ /**
  * Play our intro menu to the specified channel
  * 
  * Since we want to interrupt the playback of the menu when the user presses
@@ -930,7 +930,7 @@ function clientLoaded (err, client) {
  if (!state.done) {
  // have we played all sounds in the menu?
  if (!state.currentSound) {
- var timer = setTimeout(stillThere, 10 \* 1000);
+ var timer = setTimeout(stillThere, 10 * 1000);
  timers[channel.id] = timer;
  } else {
  var playback = client.Playback();

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/ARI-and-Media-Part-1-Recording.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/ARI-and-Media-Part-1-Recording.md
@@ -346,9 +346,9 @@ def on_dtmf(self, channel, event):
 		self.recording.stop()
 		self.call.state_machine.change_state(Event.DTMF_OCTOTHORPE)
 	# NEW CONTENT
-	elif digit == '\*':
+	elif digit == '*':
 		rec_name = self.recording.json.get('name')
-		print "Canceling recording {0} on DTMF \*".format(rec_name)
+		print "Canceling recording {0} on DTMF *".format(rec_name)
 		self.cleanup()
 		self.recording.cancel()
 		self.call.state_machine.change_state(Event.DTMF_STAR)
@@ -365,7 +365,7 @@ function on_dtmf(event, channel) {
 		});
 		break;
 	// NEW CONTENT
-	case '\*':
+	case '*':
 		console.log("Canceling recording", call.vm_path);
 		cleanup();
 		recording.cancel(function(err) {
@@ -415,11 +415,11 @@ This is exactly the same as it was, except for the penultimate line adding the `
 Channel PJSIP/200-00000007 recording voicemail for 305
 Entering recording state
 Recording voicemail at voicemail/305/1411498790.65
-Canceling recording voicemail/305/1411498790.65 on DTMF \*
+Canceling recording voicemail/305/1411498790.65 on DTMF *
 Cleaning up event handlers
 Entering recording state
 Recording voicemail at voicemail/305/1411498790.65
-Canceling recording voicemail/305/1411498790.65 on DTMF \*
+Canceling recording voicemail/305/1411498790.65 on DTMF *
 Cleaning up event handlers
 Entering recording state
 Recording voicemail at voicemail/305/1411498790.65
@@ -495,8 +495,8 @@ class ReviewingState(object):
 			print("Accepted recording {0} on DTMF #".format(self.call.vm_path))
 			self.cleanup()
 			self.call.state_machine.change_state(Event.DTMF_OCTOTHORPE)
-		elif digit == '\*':
-			print("Discarding stored recording {0} on DTMF \*".format(self.call.vm_path))
+		elif digit == '*':
+			print("Discarding stored recording {0} on DTMF *".format(self.call.vm_path))
 			self.cleanup()
 			self.call.client.recordings.deleteStored(
 				recordingName=self.call.vm_path)
@@ -547,7 +547,7 @@ function ReviewingState(call) {
 				cleanup();
 				call.state_machine.change_state(Event.DTMF_OCTOTHORPE);
 				break;
-			case '\*':
+			case '*':
 				console.log("Canceling recording", call.vm_path);
 				cleanup();
 				call.client.recordings.deleteStored({recordingName: call.vm_path});
@@ -625,7 +625,7 @@ Recording voicemail at voicemail/305/1411501058.42
 Accepted recording voicemail/305/1411501058.42 on DTMF #
 Cleaning up event handlers
 Entering reviewing state
-Discarding stored recording voicemail/305/1411501058.42 on DTMF \*
+Discarding stored recording voicemail/305/1411501058.42 on DTMF *
 Entering recording state
 Recording voicemail at voicemail/305/1411501058.42
 Accepted recording voicemail/305/1411501058.42 on DTMF #

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/ARI-and-Media-Part-2-Playbacks.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/ARI-and-Media-Part-2-Playbacks.md
@@ -804,7 +804,7 @@ class ListeningState(object):
 		elif digit == '#':
 			self.cleanup()
 			self.call.state_machine.change_state(Event.DTMF_OCTOTHORPE)
-		elif digit == '\*':
+		elif digit == '*':
 			print("Deleting stored recording {0}".format(
 				self.call.get_current_voicemail_file()))
 			self.cleanup()
@@ -903,7 +903,7 @@ function ListeningState(call) {
 				cleanup();
 				call.state_machine.change_state(Event.DTMF_OCTOTHORPE);
 				break;
-			case '\*':
+			case '*':
 				console.log("Deleting stored recording", call.get_current_voicemail_file());
 				cleanup();
 				call.client.recordings.deleteStored({recordingName:call.get_current_voicemail_file()});

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/index.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/index.md
@@ -48,7 +48,7 @@ class Event(object):
  # Use "octothorpe" so there is no confusion about "pound" or "hash"
  # terminology.
  DTMF_OCTOTHORPE = "#"
- DTMF_STAR = "\*"
+ DTMF_STAR = "*"
  # Call has hung up
  HANGUP = "hangup"
  # Playback of a file has completed
@@ -73,7 +73,7 @@ var Event = {
  // Use "octothorpe" so there is no confusion about "pound" or "hash"
  // terminology.
  DTMF_OCTOTHORPE: "#",
- DTMF_STAR: "\*",
+ DTMF_STAR: "*",
  // Call has hung up
  HANGUP: "hangup",
  // Playback of a file has completed

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/The-Asterisk-Resource/ARI-Push-Configuration.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/The-Asterisk-Resource/ARI-Push-Configuration.md
@@ -366,7 +366,7 @@ And we can confirm that Alice no longer exists:
 ```text title="Asterisk CLI"
 *CLI> pjsip show endpoints
 No objects found.
-\*CLI> database show
+*CLI> database show
 0 results found.
 *CLI> 
 ```

--- a/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/Followme-Realtime.md
+++ b/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/Followme-Realtime.md
@@ -19,7 +19,7 @@ followme:
  music
  context Dialplan context from which to dial numbers
  takecall DTMF used to accept the call and be connected. For obvious reasons,
- this needs to be a single digit, '\*', or '#'.
+ this needs to be a single digit, '*', or '#'.
  declinecall DTMF used to refuse the call, sending it onto the next step, if any.
  call_from_prompt Prompt to play to the callee, announcing the call.
  norecording_prompt The alternate prompt to play to the callee, when the caller

--- a/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Configuring-res_odbc.md
+++ b/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Configuring-res_odbc.md
@@ -42,7 +42,7 @@ pre-connect => yes
 Then start up Asterisk and assuming res_odbc loads properly on the CLI you can use odbc show to verify a DSN is configured and shows up:
 
 ```
-rnewton-office-lab\*CLI> odbc show
+rnewton-office-lab*CLI> odbc show
 ODBC DSN Settings
 -----------------
  Name: asterisk

--- a/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Getting-Asterisk-Connected-to-MySQL-via-ODBC.md
+++ b/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Getting-Asterisk-Connected-to-MySQL-via-ODBC.md
@@ -45,7 +45,7 @@ Now verify you are at the MySQL command prompt. It should look like "mysql>". Th
 ```bash title=" " linenums="1"
 # CREATE USER 'asterisk'@'%' IDENTIFIED BY 'replace_with_strong_password';
 # CREATE DATABASE asterisk;
-# GRANT ALL PRIVILEGES ON asterisk.\* TO 'asterisk'@'%';
+# GRANT ALL PRIVILEGES ON asterisk.* TO 'asterisk'@'%';
 # exit
 
 ```

--- a/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/cURL.md
+++ b/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/cURL.md
@@ -73,7 +73,7 @@ $ asterisk -c
 Once Asterisk has started, type the following on the CLI:
 
 ```
-\*CLI> module show like res_config_curl
+*CLI> module show like res_config_curl
 Module Description Use Count Status
 res_config_curl.so Realtime Curl configuration 0 Running
 1 modules loaded

--- a/docs/Configuration/Interfaces/Distributed-Device-State/Corosync.md
+++ b/docs/Configuration/Interfaces/Distributed-Device-State/Corosync.md
@@ -201,7 +201,7 @@ If everything is setup correctly, you should see this output after executing a '
 
 ```
 
-\*CLI> corosync show members
+*CLI> corosync show members
 
 =============================================================
 === Cluster members =========================================
@@ -219,7 +219,7 @@ After starting Corosync and Asterisk on your second node, the 'corosync show mem
 
 ```
 
-\*CLI> corosync show members 
+*CLI> corosync show members 
 
 =============================================================
 === Cluster members =========================================

--- a/docs/Configuration/Interfaces/Distributed-Device-State/Distributed-Device-State-with-AIS.md
+++ b/docs/Configuration/Interfaces/Distributed-Device-State/Distributed-Device-State-with-AIS.md
@@ -124,7 +124,7 @@ $ sudo cp configs/ais.conf.sample /etc/asterisk/ais.conf
 First, ensure that you have a unique "entity ID" set for each server.
 
 ```
-\*CLI> core show settings
+*CLI> core show settings
  ...
  Entity ID: 01:23:45:67:89:ab
 ```
@@ -167,7 +167,7 @@ The first thing to test is to verify that all of the nodes that you think should
 (CLM).
 
 ```
-\*CLI> ais clm show members 
+*CLI> ais clm show members 
 
 =============================================================
 === Cluster Members =========================================
@@ -196,7 +196,7 @@ If you're having trouble getting the nodes of the cluster to see each other, mak
 The next thing to do is to verify that you have successfully configured some event channels in the Asterisk ais.conf file. This command is related to the event service (EVT), so like the previous command, uses the syntax: `ais <service name> <command>`.
 
 ```
-\*CLI> ais evt show event channels 
+*CLI> ais evt show event channels 
 
 =============================================================
 === Event Channels ==========================================
@@ -225,24 +225,24 @@ exten => 1234,hint,Custom:mystate
 Now, you can test that the cluster-wide state of "Custom:mystate" is what you would expect after going to the CLI of each server and adjusting the state.
 
 ```
-server1\*CLI> dialplan set global DEVICE_STATE(Custom:mystate) NOT_INUSE
+server1*CLI> dialplan set global DEVICE_STATE(Custom:mystate) NOT_INUSE
  ...
 
-server2\*CLI> dialplan set global DEVICE_STATE(Custom:mystate) INUSE
+server2*CLI> dialplan set global DEVICE_STATE(Custom:mystate) INUSE
  ...
 ```
 Various combinations of setting and checking the state on different servers can be used to verify that it works as expected. Also, you can see the status of the hint on each server, as well, to see how extension state would reflect the
 state change with distributed device state:
 
 ```
-server2\*CLI> core show hints
+server2*CLI> core show hints
  -= Registered Asterisk Dial Plan Hints =-
  1234@devstate_test : Custom:mystate State:InUse Watchers 0
 ```
 One other helpful thing here during testing and debugging is to enable debug logging. To do so, enable debug on the console in /etc/asterisk/logger.conf. Also, enable debug at the Asterisk CLI.
 
 ```
-\*CLI> core set debug 1
+*CLI> core set debug 1
 ```
 When you have this debug enabled, you will see output during the processing of every device state change. The important thing to look for is where the known state of the device for each server is added together to determine the overall
 state.

--- a/docs/Configuration/Interfaces/Distributed-Device-State/Distributed-Device-State-with-XMPP-PubSub.md
+++ b/docs/Configuration/Interfaces/Distributed-Device-State/Distributed-Device-State-with-XMPP-PubSub.md
@@ -213,7 +213,7 @@ We need to start up our first server and make sure we get connected to the XMPP 
 On Asterisk 1 we can run 'jabber show connected' to verify we're connected to the XMPP server.
 
 ```
-\*CLI> jabber show connected 
+*CLI> jabber show connected 
 Jabber Users and their status:
  User: server1@asterisk.mydomain.tld/astvoip1 - Connected
 ----
@@ -224,7 +224,7 @@ The command above has given us output which verifies we've connected our first s
 We can then check the state of our buddies with the 'jabber show buddies' CLI command.
 
 ```
-\*CLI> jabber show buddies
+*CLI> jabber show buddies
 Jabber buddy lists
 Client: server1@asterisk.mydomain.tld/astvoip1
  Buddy: server2@asterisk.mydomain.tld
@@ -239,7 +239,7 @@ Now, let's start the other server and verify the servers are able to establish a
 On Asterisk 2, again we run the 'jabber show connected' command to make sure we've connected successfully to the XMPP server.
 
 ```
-\*CLI> jabber show connected 
+*CLI> jabber show connected 
 Jabber Users and their status:
  User: server2@asterisk.mydomain.tld/astvoip2 - Connected
 ----
@@ -248,7 +248,7 @@ Jabber Users and their status:
 And now we can check the status of our buddies.
 
 ```
-\*CLI> jabber show buddies
+*CLI> jabber show buddies
 Jabber buddy lists
 Client: server2@scooter/astvoip2
  Buddy: server1@asterisk.mydomain.tld
@@ -280,24 +280,24 @@ exten => check,1,NoOp(Custom:mystate is ${DEVICE_STATE(Custom:mystate)})
 Now, you can test that the cluster-wide state of "Custom:mystate" is what you would expect after going to the CLI of each server and adjusting the state.
 
 ```
-server1\*CLI> console dial set_inuse@devstate_test
+server1*CLI> console dial set_inuse@devstate_test
  ...
 
-server2\*CLI> console dial check@devstate_test
+server2*CLI> console dial check@devstate_test
  -- Executing [check@devstate_test:1] NoOp("OSS/dsp", "Custom:mystate is INUSE") in new stack
 ```
 Various combinations of setting and checking the state on different servers can be used to verify that it works as expected. Also, you can see the status of the hint on each server, as well, to see how extension state would reflect the
 state change with distributed device state: 
 
 ```
-server2\*CLI> core show hints
+server2*CLI> core show hints
  -= Registered Asterisk Dial Plan Hints =-
  1234@devstate_test : Custom:mystate State:InUse Watchers 0
 ```
 One other helpful thing here during testing and debugging is to enable debug logging. To do so, enable debug on the console in /etc/asterisk/logger.conf. Also, enable debug at the Asterisk CLI.
 
 ```
-\*CLI> core set debug 1
+*CLI> core set debug 1
 ```
 When you have this debug enabled, you will see output during the processing of every device state change. The important thing to look for is where the known state of the device for each server is added together to determine the overall
 state.

--- a/docs/Configuration/Reporting/Call-Detail-Records-CDR/CDR-Specification.md
+++ b/docs/Configuration/Reporting/Call-Detail-Records-CDR/CDR-Specification.md
@@ -6,9 +6,9 @@ pageid: 22088359
 Call Detail Records, or CDRs, have been around in Asterisk for a long, long time. In fact, portions of it were taken from the `Zapata` library, as noted in `cdr.c`:
 
 ```
- \*
- \* \note Includes code and algorithms from the Zapata library.
- \*
+ *
+ * \note Includes code and algorithms from the Zapata library.
+ *
 ```
 
 CDRs have always attempted to provide the billing information between two parties involved in a call. While their simplicity has been a big advantage in quickly deploying a billing system, it has also been their largest disadvantage when trying to express complex scenarios. As Asterisk evolved and adapted to more complex scenarios, it became difficult to express the full details of a call within a single CDR. Compounding this problem, the way in which bridging was performed in Asterisk made call scenarios involving more than two parties incredibly difficult to track and coalesce into one or more CDRs. Numerous attempts were made to address the various problems in CDRs with varying degrees of success.

--- a/docs/Configuration/WebRTC/Configuring-Asterisk-for-WebRTC-Clients.md
+++ b/docs/Configuration/WebRTC/Configuring-Asterisk-for-WebRTC-Clients.md
@@ -56,10 +56,10 @@ Generating RSA private key, 4096 bit long modulus
 ............................................................................++
 .....................++
 e is 65537 (0x010001)
-Enter pass phrase for /etc/asterisk/keys/ca.key:\*\*\*\*\*\*\*\*
-Verifying - Enter pass phrase for /etc/asterisk/keys/ca.key:\*\*\*\*\*\*\*\*
+Enter pass phrase for /etc/asterisk/keys/ca.key:********
+Verifying - Enter pass phrase for /etc/asterisk/keys/ca.key:********
 Creating CA certificate /etc/asterisk/keys/ca.crt
-Enter pass phrase for /etc/asterisk/keys/ca.key:\*\*\*\*\*\*\*\*
+Enter pass phrase for /etc/asterisk/keys/ca.key:********
 Creating certificate /etc/asterisk/keys/asterisk.key
 Generating RSA private key, 1024 bit long modulus
 ........++++++
@@ -70,7 +70,7 @@ Creating certificate /etc/asterisk/keys/asterisk.crt
 Signature ok
 subject=CN = pbx.example.com, O = My Organization
 Getting CA Private Key
-Enter pass phrase for /etc/asterisk/keys/ca.key:\*\*\*\*\*\*\*\*
+Enter pass phrase for /etc/asterisk/keys/ca.key:********
 Combining key and crt into /etc/asterisk/keys/asterisk.pem
 
 $ ls -l /etc/asterisk/keys

--- a/docs/Configuration/WebRTC/Installing-and-Configuring-CyberMegaPhone.md
+++ b/docs/Configuration/WebRTC/Installing-and-Configuring-CyberMegaPhone.md
@@ -66,7 +66,7 @@ Asterisk CLI
 
 ```
 
-\*CLI> http show status
+*CLI> http show status
 HTTP Server Status:
 Prefix: 
 Server: Asterisk/GIT-16-a84c257cd6

--- a/docs/Deployment/Basic-PBX-Functionality/Auto-attendant-and-IVR-Menus/Record-Application.md
+++ b/docs/Deployment/Basic-PBX-Functionality/Auto-attendant-and-IVR-Menus/Record-Application.md
@@ -43,7 +43,7 @@ You've now learned the basics of how to create a simple auto-attendant menu. Now
 	exten => 2,1,Goto(users,6002,1)
 
 	exten => 9,1,Directory(vm-demo,users,fe)
-	exten => \*,1,VoiceMailMain(@vm-demo)
+	exten => *,1,VoiceMailMain(@vm-demo)
 
 	exten => i,1,Playback(option-is-invalid) 
 	same => n,Goto(s,loop)

--- a/docs/Deployment/Basic-PBX-Functionality/Making-a-Phone-Call.md
+++ b/docs/Deployment/Basic-PBX-Functionality/Making-a-Phone-Call.md
@@ -6,7 +6,7 @@ pageid: 4817414
 At this point, you should be able to pick up Alice's phone and dial extension **6002** to call Bob, and dial **6001** from Bob's phone to call Alice. As you make a few test calls, be sure to watch the Asterisk command-line interface (and ensure that your verbosity is set to a value three or higher) so that you can see the messages coming from Asterisk, which should be similar to the ones below:
 
 ```
-server\*CLI>     -- Executing [6002@from-internal:1] Dial("SIP/demo-alice-00000000", "SIP/demo-bob,20") in new stack
+server*CLI>     -- Executing [6002@from-internal:1] Dial("SIP/demo-alice-00000000", "SIP/demo-bob,20") in new stack
  -- Called demo-bob
  -- SIP/demo-bob-00000001 is ringing
  -- SIP/demo-bob-00000001 answered SIP/demo-alice-00000000

--- a/docs/Deployment/Basic-PBX-Functionality/Registering-Phones-to-Asterisk.md
+++ b/docs/Deployment/Basic-PBX-Functionality/Registering-Phones-to-Asterisk.md
@@ -15,7 +15,7 @@ Configuring your particular phone is obviously beyond the scope of this guide, b
 When using chan_sip you can tell whether or not your phone has registered successfully to Asterisk by checking the output of the **sip show peers** command at the Asterisk CLI. If the **Host** column says **(Unspecified)**, the phone has not yet registered. On the other hand, if the **Host** column contains an IP address and the **Dyn** column contains the letter **D**, you know that the phone has successfully registered.
 
 ```
-server\*CLI> sip show peers
+server*CLI> sip show peers
 Name/username Host Dyn NAT ACL Port Status
 demo-alice (Unspecified) D A 5060 Unmonitored
 demo-bob 192.168.5.105 D A 5060 Unmonitored

--- a/docs/Deployment/Media-Experience-Score/index.md
+++ b/docs/Deployment/Media-Experience-Score/index.md
@@ -24,7 +24,7 @@ We’ll be reducing a given transmission rating factor, or ‘R’ value for sho
 Let’s start with latency. Depending on the situation the media itself may or may not be affected by late arriving packets, but the overall user experience may suffer. For example, If you’re on a VOIP call and audio is delayed by a second it makes it harder to have a conversation. As well if packets arrive out of order, and no jitter buffer is enabled that too will make for an unpleasant experience. To that end we can compute an “effective latency” (in milliseconds), and reduce the ‘R’ value accordingly:
 
 ```text
-Effective Latency = Average Round Trip Time + Average Jitter \* 2 \* (Jitter Standard Deviation / 3) + Codec Delay
+Effective Latency = Average Round Trip Time + Average Jitter * 2 * (Jitter Standard Deviation / 3) + Codec Delay
 If Effective Latency < 160: R = 93.2 - (Effective Latency / 40)
 Else: R = 93.2 - (Effective Latency - 120) / 10
 ```
@@ -34,7 +34,7 @@ Multiplying the jitter, and factoring in its standard deviation adds to its “w
 Next up is packet loss. If anything is going to have a known effect on media quality it’s packet loss. Again we can further reduce the ‘R’ value according to average number of packets lost since the last report:
 
 ```text
-R = R - Packets Lost \* 2.5
+R = R - Packets Lost * 2.5
 ```
 
 /// note
@@ -47,7 +47,7 @@ All that is needed to do now is convert the ‘R’ value into an “opinion sco
 ```text
 If R < 0: Opinion = 1
 Else if R > 100: Opinion = 4.5
-Else: Opinion = 1 + (0.035 \* R) + (R \* (R - 60) \* (100 - R) \* 0.0000007);
+Else: Opinion = 1 + (0.035 * R) + (R * (R - 60) * (100 - R) * 0.0000007);
 ```
 
 ## In Asterisk

--- a/docs/Deployment/Performance-Tuning.md
+++ b/docs/Deployment/Performance-Tuning.md
@@ -95,7 +95,7 @@ type=system
 timer_t1=100
 
 ; Timer B is technically the INVITE transaction timeout but it also controls other aspects
-; of stack timing. It's default is 32 seconds but its minimum is (64 \* timer_t1) which
+; of stack timing. It's default is 32 seconds but its minimum is (64 * timer_t1) which
 ; would also be 32 seconds if timer_t1 were left at its default of 500ms. Unfortunately,
 ; this timer has the side effect of controlling how long completed transactions are kept in
 ; memory so on a busy PBX, a setting of 32 seconds will probably result in higher than

--- a/docs/Deployment/Troubleshooting/Troubleshooting-Asterisk-Module-Loading.md
+++ b/docs/Deployment/Troubleshooting/Troubleshooting-Asterisk-Module-Loading.md
@@ -43,7 +43,7 @@ From the [Asterisk CLI](/Operation/Asterisk-Command-Line-Interface) you can use 
 Previous to Asterisk 12, you could only see if the module is loaded. However it may not actually be running (usable).
 
 ```
-\*CLI> module show like chan_sip.so 
+*CLI> module show like chan_sip.so 
 Module Description Use Count 
 chan_sip.so Session Initiation Protocol (SIP) 0 
 1 modules loaded
@@ -53,7 +53,7 @@ chan_sip.so Session Initiation Protocol (SIP) 0
 In Asterisk 12 and beyond you can quickly see if a module is loaded and whether it is running or not.
 
 ```
-\*CLI> module show like chan_sip.so 
+*CLI> module show like chan_sip.so 
 Module Description Use Count Status
 chan_sip.so Session Initiation Protocol (SIP) 0 Not Running
 1 modules loaded
@@ -141,7 +141,7 @@ You'll see a lot of information output in the terminal as Asterisk loads.
 After the output calms down and Asterisk has finished loading, go ahead and stop Asterisk. The logs should have already been recorded.
 
 ```
-\*CLI> core stop now
+*CLI> core stop now
 
 ```
 

--- a/docs/Development/Debugging/CLI-commands-useful-for-debugging.md
+++ b/docs/Development/Debugging/CLI-commands-useful-for-debugging.md
@@ -23,7 +23,7 @@ Examples: (both a lock during a feature code attended transfer)
 Example output with DEBUG_THREADS only
 
 ```
-ubuntu\*CLI> core show locks
+ubuntu*CLI> core show locks
 
 =======================================================================
 === Currently Held Locks ==============================================
@@ -57,7 +57,7 @@ ubuntu\*CLI> core show locks
 Example output with DEBUG_THREADS and BETTER_BACKTRACES
 
 ```
-ubuntu\*CLI> core show locks
+ubuntu*CLI> core show locks
 
 =======================================================================
 === Currently Held Locks ==============================================
@@ -95,7 +95,7 @@ List instantiated task processors and statistics
 Example command output
 
 ```
-ubuntu\*CLI> core show taskprocessors
+ubuntu*CLI> core show taskprocessors
 
  +----- Processor -----+--- Processed ---+- In Queue -+- Max Depth -+
  app_queue 8 0 0
@@ -113,7 +113,7 @@ ubuntu\*CLI> core show taskprocessors
 Example command output (Asterisk 13)
 
 ```
-\*CLI> core show taskprocessors
+*CLI> core show taskprocessors
 Processor Processed In Queue Max Depth Low water High water
 app_voicemail 0 0 0 450 500
 ast_msg_queue 0 0 0 450 500
@@ -150,7 +150,7 @@ Shows running threads!  Doesn't require any compilation flags to be set.
 Example command output
 
 ```
-ubuntu\*CLI> core show threads
+ubuntu*CLI> core show threads
 0x7f869a7fb700 25102 netconsole started at [ 1442] asterisk.c listener()
 0x7f869a877700 25100 tps_processing_function started at [ 471] taskprocessor.c ast_taskprocessor_get()
 0x7f869a8f3700 25099 do_monitor started at [ 5743] chan_unistim.c restart_monitor()
@@ -172,7 +172,7 @@ This command is not available until you compile Asterisk with [DEBUG_FD_LEAKS](/
 Shows file descriptors open by Asterisk.
 
 ```
-newtonr-laptop\*CLI> core show fd
+newtonr-laptop*CLI> core show fd
 Current maxfiles: unlimited
  3 utils.c:2310 (ast_utils_init ): open("/dev/urandom",0)
  5 asterisk.c:1626 (ast_makesocket ): socket(PF_UNIX,SOCK_STREAM,"tcp")

--- a/docs/Development/Debugging/Getting-a-Backtrace-Asterisk-versions-13.14.0-and-14.3.0.md
+++ b/docs/Development/Debugging/Getting-a-Backtrace-Asterisk-versions-13.14.0-and-14.3.0.md
@@ -162,8 +162,8 @@ No symbol table info available.
 #12 0x00000000 in ?? ()
 No symbol table info available.
 #13 0x407513c3 in confcall_careful_stream (conf=0x8180bf8, filename=0x8181de8 "DAHDI/pseudo-1324221520") at app_meetme.c:262
- f = (struct ast_frame \*) 0x8180bf8
- trans = (struct ast_trans_pvt \*) 0x0
+ f = (struct ast_frame *) 0x8180bf8
+ trans = (struct ast_trans_pvt *) 0x0
 #14 0x40751332 in streamconfthread (args=0x8180bf8) at app_meetme.c:1965
 No locals.
 #15 0xbcdffbe0 in ?? ()

--- a/docs/Development/Debugging/Getting-a-Backtrace.md
+++ b/docs/Development/Debugging/Getting-a-Backtrace.md
@@ -137,12 +137,12 @@ DESCRIPTION
  specified on the command line the value of COREDUMPS from
  ast_debug_tools.conf will be used. Failing that, the following
  patterns will be used:
- /tmp/core[-._]asterisk!(\*.txt)
- /tmp/core[-._]$(hostname)!(\*.txt)
+ /tmp/core[-._]asterisk!(*.txt)
+ /tmp/core[-._]$(hostname)!(*.txt)
 NOTES
  You must be root to use ast_coredumper.
  The script relies on not only bash, but also recent GNU date and
- gdb with python support. \*BSD operating systems may require
+ gdb with python support. *BSD operating systems may require
  installation of the 'coreutils' and 'devel/gdb' packagess and minor
  tweaking of the ast_debug_tools.conf file.
  Any files output will have ':' characters changed to '-'. This is
@@ -171,7 +171,7 @@ FILES
  # The exclusion of files ending ".txt" is just for
  # demonstration purposes as non-coredumps will be ignored
  # anyway.
- COREDUMPS=(/tmp/core[-._]asterisk!(\*.txt) /tmp/core[-._]$(hostname)!(\*.txt))
+ COREDUMPS=(/tmp/core[-._]asterisk!(*.txt) /tmp/core[-._]$(hostname)!(*.txt))
  # Date command for the "running" coredump and tarballs.
  # DATEFORMAT will be executed to get the timestamp.
  # Don't put quotes around the format string or they'll be
@@ -182,7 +182,7 @@ FILES
  # Unix timestamp
  #DATEFORMAT='date +%s.%N'
  #
- # \*BSD/MacOS doesn't support %N but after installing GNU
+ # *BSD/MacOS doesn't support %N but after installing GNU
  # coreutils...
  #DATEFORMAT='gdate +%s.%N'
  #
@@ -217,7 +217,7 @@ Many system administrators use the sysctl `kernel.core_pattern` parameter to con
 ```bash title=" " linenums="1"
 $ sysctl -n kernel.core_pattern
 /tmp/core-%e-%t
-$ ls -al /tmp/core-asterisk\*
+$ ls -al /tmp/core-asterisk*
 -rw-------. 1 root root 173936640 Jun 16 07:44 /tmp/core-asterisk-1497620664.32259
 $ sudo /var/lib/asterisk/scripts/ast_coredumper /tmp/core-asterisk-1497620664.32259 
 Processing /tmp/core-asterisk-1497620664.32259

--- a/docs/Development/Debugging/Reference-Count-Debugging.md
+++ b/docs/Development/Debugging/Reference-Count-Debugging.md
@@ -83,7 +83,7 @@ Each change in the reference count value of an `ao2` object will generate one li
 
 ```
 ...
-0x7f9dbc002048,+1,19256,chan_sip.c,8651,sip_alloc,\*\*constructor\*\*,allocate a dialog(pvt) struct
+0x7f9dbc002048,+1,19256,chan_sip.c,8651,sip_alloc,**constructor**,allocate a dialog(pvt) struct
 0x7f9dbc002048,+1,19256,chan_sip.c,8795,sip_alloc,1,link pvt into dialogs table
 0x7f9dbc002048,+1,19256,chan_sip.c,4186,__sip_reliable_xmit,2,__sip_reliable_xmit: setting pkt->owner
 0x7f9dbc002048,+1,19256,chan_sip.c,4352,sip_scheddestroy,3,setting ref as passing into ast_sched_add for __sip_autodestruct
@@ -96,7 +96,7 @@ Each change in the reference count value of an `ao2` object will generate one li
 0x7f9dbc002048,-1,19256,chan_sip.c,3286,dialog_unlink_all,4,unlinking dialog via ao2_unlink
 0x7f9dbc002048,-1,19256,chan_sip.c,3287,dialog_unlink_all,3,unlinking dialog_needdestroy via ao2_unlink
 0x7f9dbc002048,-1,19256,chan_sip.c,3335,dialog_unlink_all,2,when you delete the autokillid sched, you should dec the refcount for the stored dialog ptr
-0x7f9dbc002048,-1,19256,chan_sip.c,3352,dialog_unlink_all,\*\*destructor\*\*,Let's unbump the count in the unlink so the poor pvt can disappear if it is time
+0x7f9dbc002048,-1,19256,chan_sip.c,3352,dialog_unlink_all,**destructor**,Let's unbump the count in the unlink so the poor pvt can disappear if it is time
 ...
 
 ```

--- a/docs/Development/Policies-and-Procedures/Coding-Guidelines.md
+++ b/docs/Development/Policies-and-Procedures/Coding-Guidelines.md
@@ -72,7 +72,7 @@ Keep the number of header files small by not including them unnecessarily. Don't
 \* Functions and variables that are not intended to be used outside the module must be declared static. If you are compiling on a Linux platform that has the 'dwarves' package available, you can use the 'pglobal' tool from that package to check for unintended global variables or functions being exposed in your object files. Usage is very simple:
 
 ```
-$ pglobal \-vf <path to .o file>
+$ pglobal -vf <path to .o file>
 ```
 
 \* When reading integer numeric input with scanf (or variants), do \_NOT\_ use '%i' unless you specifically want to allow non-base-10 input; '%d' is always a better choice, since it will not silently turn numbers with leading zeros into base-8.
@@ -85,14 +85,14 @@ On many platforms, structure fields (in structures that are not marked 'packed')
 ```C
 struct foo {
  int bar;
- void \*xyz;
+ void *xyz;
 }
 ```
 
 On nearly every 64-bit platform, this will result in 4 bytes of dead space between 'bar' and 'xyz', because pointers on 64-bit platforms must be aligned on 8-byte boundaries. Once you have your code written and tested, it may be worthwhile to review your structure definitions to look for problems of this nature. If you are on a Linux platform with the 'dwarves' package available, the 'pahole' tool from that package can be used to both check for padding issues of this type and also propose reorganized structure definitions to eliminate it. Usage is quite simple; for a structure named 'foo', the command would look something like this:
 
 ```
-$ pahole \--reorganize \--show\_reorg\_steps \-C foo <path to module>
+$ pahole --reorganize --show_reorg_steps -C foo <path to module>
 ```
 
 The 'pahole' tool has many other modes available, including some that will list all the structures declared in the module and the amount of padding in each one that could possibly be recovered.
@@ -157,7 +157,7 @@ Following are examples of how code should be formatted.
 
 #### Functions:
 ```C
-int foo(int a, char \*s)
+int foo(int a, char *s)
 {
  return 0;
 }
@@ -209,7 +209,7 @@ Always use braces around the statements following an if/for/while construct, eve
 Don't build code like this:
 ```C
 if (foo) {
- /\* .... 50 lines of code ... \*/
+ /* .... 50 lines of code ... */
 } else {
  result = 0;
  return;
@@ -270,14 +270,14 @@ In fact, don't use 'variable type' suffixes at all; it's much preferable to just
 Use enums rather than long lists of #define-d numeric constants when possible; this allows structure members, local variables and function arguments to be declared as using the enum's type. For example:
 ```C
 enum option {
- OPT\_FOO = 1,
- OPT\_BAR = 2,
- OPT\_BAZ = 4,
+ OPT_FOO = 1,
+ OPT_BAR = 2,
+ OPT_BAZ = 4,
 };
 
-static enum option global\_option;
+static enum option global_option;
 
-static handle\_option(const enum option opt)
+static handle_option(const enum option opt)
 {
  ...
 }
@@ -307,19 +307,19 @@ For the sake of uclibc, do not use index, bcopy or bzero; use strchr(), memset()
 When making applications, always ast\_strdupa(data) to a local pointer if you intend to parse the incoming data string.
 ```C
  if (data) {
- mydata = ast\_strdupa(data);
+ mydata = ast_strdupa(data);
  }
 ```
 
 Use the argument parsing macros to declare arguments and parse them, i.e.:
 ```C
- AST\_DECLARE\_APP\_ARGS(args,
- AST\_APP\_ARG(arg1);
- AST\_APP\_ARG(arg2);
- AST\_APP\_ARG(arg3);
+ AST_DECLARE_APP_ARGS(args,
+ AST_APP_ARG(arg1);
+ AST_APP_ARG(arg2);
+ AST_APP_ARG(arg3);
  );
- parse = ast\_strdupa(data);
- AST\_STANDARD\_APP\_ARGS(args, parse);
+ parse = ast_strdupa(data);
+ AST_STANDARD_APP_ARGS(args, parse);
 ```
 
 Make sure you are not duplicating any functionality already found in an API call somewhere. If you are duplicating functionality found in
@@ -343,11 +343,11 @@ use them when possible.
 
 When allocating/zeroing memory for a structure, use code like this:
 ```C
-struct foo \*tmp;
+struct foo *tmp;
 
 ...
 
-tmp = ast\_calloc(1, sizeof(\*tmp));
+tmp = ast_calloc(1, sizeof(*tmp));
 ```
 
 Avoid the combination of ast\_malloc() and memset(). Instead, always use ast\_calloc(). This will allocate and zero the memory in a single operation. In the case that uninitialized memory is acceptable, there should be a comment in the code that states why this is the case.
@@ -369,7 +369,7 @@ The functions strdup and strndup can \*not\* accept a NULL argument. This result
 However, the ast\_strdup and ast\_strdupa functions will happily accept a NULL
 argument without generating an error. The same code can be written as:
 ```C
- newstr = ast\_strdup(str);
+ newstr = ast_strdup(str);
 ```
 Furthermore, it is unnecessary to have code that malloc/calloc's for the length of a string (+1 for the terminating '\0') and then using strncpy to copy the copy the string into the resulting buffer. This is the exact same thing as using ast\_strdup.
 
@@ -377,11 +377,11 @@ Furthermore, it is unnecessary to have code that malloc/calloc's for the length 
 
 New CLI commands should be named using the module's name, followed by a verb and then any parameters that the command needs. For example:
 ```
-\*CLI> iax2 show peer <peername>
+*CLI> iax2 show peer <peername>
 ```
 not
 ```
-\*CLI> show iax2 peer <peername>
+*CLI> show iax2 peer <peername>
 ```
 
 ### New dialplan applications/functions
@@ -399,18 +399,18 @@ Functions are registered using 'struct ast\_custom\_function' structures and the
 When writing Asterisk API documentation the following format should be followed. Do not use the javadoc style.
 
 ```C
-/\*!
- \* \brief Do interesting stuff.
- \*
- \* \param thing1 interesting parameter 1.
- \* \param thing2 interesting parameter 2.
- \*
- \* This function does some interesting stuff.
- \*
- \* \retval zero on success
- \* \retval -1 on error.
- \*/
-int ast\_interesting\_stuff(int thing1, int thing2)
+/*!
+ * \brief Do interesting stuff.
+ *
+ * \param thing1 interesting parameter 1.
+ * \param thing2 interesting parameter 2.
+ *
+ * This function does some interesting stuff.
+ *
+ * \retval zero on success
+ * \retval -1 on error.
+ */
+int ast_interesting_stuff(int thing1, int thing2)
 {
  return 0;
 }
@@ -426,15 +426,15 @@ When adding new API you should also attach a \since note because this will indic
 
 Structures should be documented as follows.
 ```C
-/\*!
- \* \brief A very interesting structure.
- \*/
-struct interesting\_struct
+/*!
+ * \brief A very interesting structure.
+ */
+struct interesting_struct
 {
- /\*! \brief A data member. \*/
+ /*! \brief A data member. */
  int member1;
 
- int member2; /\*!< \brief Another data member. \*/
+ int member2; /*!< \brief Another data member. */
 }
 ```
 Note that /\\*\! \\*/ blocks document the construct immediately following them unless they are written, /\\*\!< \\*/, in which case they document the construct preceding them.

--- a/docs/Development/Reference-Information/Asterisk-Framework-and-API-Examples/Asterisk-Channel-Data-Stores.md
+++ b/docs/Development/Reference-Information/Asterisk-Framework-and-API-Examples/Asterisk-Channel-Data-Stores.md
@@ -43,12 +43,12 @@ Full Example:
 
 ```
 
-void callback_destroy(void \*data)
+void callback_destroy(void *data)
 {
  ast_free(data);
 }
 
-struct ast_datastore \*datastore = NULL;
+struct ast_datastore *datastore = NULL;
 datastore = ast_datastore_alloc(&example_datastore, NULL);
 datastore->data = mysillydata;
 ast_channel_datastore_add(chan, datastore);

--- a/docs/Development/Reference-Information/Asterisk-Framework-and-API-Examples/Create-a-new-resource-with-ARI.md
+++ b/docs/Development/Reference-Information/Asterisk-Framework-and-API-Examples/Create-a-new-resource-with-ARI.md
@@ -121,12 +121,12 @@ The parameters described in your API declaration are parsed into an `args` struc
 resource_fizzbuzz.c  
 
 ```cpp
-void ast_ari_fizzbuzz(struct ast_variable \*headers,
- struct ast_fizzbuzz_args \*args,
- struct ast_ari_response \*response)
+void ast_ari_fizzbuzz(struct ast_variable *headers,
+ struct ast_fizzbuzz_args *args,
+ struct ast_ari_response *response)
 {
- RAII_VAR(struct ast_json \*, json, NULL, ast_json_unref);
- struct ast_json \*fb;
+ RAII_VAR(struct ast_json *, json, NULL, ast_json_unref);
+ struct ast_json *fb;
  int i;
  int max = 100;
  if (args->max) {

--- a/docs/Development/Reference-Information/Asterisk-Framework-and-API-Examples/Templates-for-ao2-hash-sort-and-callback-functions..md
+++ b/docs/Development/Reference-Information/Asterisk-Framework-and-API-Examples/Templates-for-ao2-hash-sort-and-callback-functions..md
@@ -30,10 +30,10 @@ The old names are still available but deprecated until all code is converted to 
 ### Hash Function
 
 ```
-int ao2_hash_fn(const void \*obj, int flags)
+int ao2_hash_fn(const void *obj, int flags)
 {
- const struct my_object \*object;
- const char \*key;
+ const struct my_object *object;
+ const char *key;
 
  switch (flags & OBJ_SEARCH_MASK) {
  case OBJ_SEARCH_KEY:
@@ -56,11 +56,11 @@ int ao2_hash_fn(const void \*obj, int flags)
 ### Sort Function
 
 ```
-int ao2_sort_fn(const void \*obj_left, const void \*obj_right, int flags)
+int ao2_sort_fn(const void *obj_left, const void *obj_right, int flags)
 {
- const struct my_object \*object_left = obj_left;
- const struct my_object \*object_right = obj_right;
- const char \*right_key = obj_right;
+ const struct my_object *object_left = obj_left;
+ const struct my_object *object_right = obj_right;
+ const char *right_key = obj_right;
  int cmp;
 
  switch (flags & OBJ_SEARCH_MASK) {
@@ -103,7 +103,7 @@ This function should not return CMP_STOP unless you never want a container searc
  * This callback function is exactly what you get when you pass
  * NULL as the callback function.
  */
-int ao2_callback_fn_sorted_cmp(void \*obj, void \*arg, int flags)
+int ao2_callback_fn_sorted_cmp(void *obj, void *arg, int flags)
 {
  return CMP_MATCH;
 }
@@ -115,11 +115,11 @@ Unsorted containers must do more work selecting objects since traversals will ei
 ### Unsorted container cmp function
 
 ```
-int ao2_callback_fn_unsorted_cmp(void \*obj, void \*arg, int flags)
+int ao2_callback_fn_unsorted_cmp(void *obj, void *arg, int flags)
 {
- const struct my_object \*object_left = obj;
- const struct my_object \*object_right = arg;
- const char \*right_key = arg;
+ const struct my_object *object_left = obj;
+ const struct my_object *object_right = arg;
+ const char *right_key = arg;
  int cmp;
 
  switch (flags & OBJ_SEARCH_MASK) {

--- a/docs/Development/Reference-Information/Asterisk-Framework-and-API-Examples/Using-the-Configuration-Framework.md
+++ b/docs/Development/Reference-Information/Asterisk-Framework-and-API-Examples/Using-the-Configuration-Framework.md
@@ -160,9 +160,9 @@ Cmy_module - load_configuration
  */
 static int load_configuration(int reload)
 {
- struct ast_config \*cfg;
- char \*cat = NULL;
- struct ast_variable \*var;
+ struct ast_config *cfg;
+ char *cat = NULL;
+ struct ast_variable *var;
  struct ast_flags config_flags = { reload ? CONFIG_FLAG_FILEUNCHANGED : 0 };
  int res = 0;
 
@@ -325,9 +325,9 @@ static void log_module_values(void)
  */
 static int load_configuration(int reload)
 {
- struct ast_config \*cfg;
- char \*cat = NULL;
- struct ast_variable \*var;
+ struct ast_config *cfg;
+ char *cat = NULL;
+ struct ast_variable *var;
  struct ast_flags config_flags = { reload ? CONFIG_FLAG_FILEUNCHANGED : 0 };
  int res = 0;
 
@@ -342,7 +342,7 @@ static int load_configuration(int reload)
  return 0;
  }
 
- /* \*\*\* LOCK ADDED \*\*\ */
+ /* *** LOCK ADDED **\ */
  ast_config_lock(&config_lock);
 
  /* Set the default value */
@@ -387,7 +387,7 @@ static int load_configuration(int reload)
  }
 
 cleanup:
- /* \*\*\* UNLOCK ADDED \*\*\ */
+ /* *** UNLOCK ADDED **\ */
  ast_config_unlock(&config_lock);
  ast_config_destroy(cfg);
  return res;
@@ -442,7 +442,7 @@ struct global_options {
  * other items in this struct
  */
 struct module_config {
- struct global_options \*general; /*< Our global setting */
+ struct global_options *general; /*< Our global setting */
 }
 
 /*! \brief A container that holds our global module configuratio */
@@ -477,18 +477,18 @@ Well, as we mentioned previously, the configuration objects are going to be `ao2
 
 ```
 Cmodule_config Constructor/Destructor
-static void \*module_config_alloc(void);
-static void module_config_destructor(void \*obj);
+static void *module_config_alloc(void);
+static void module_config_destructor(void *obj);
 
 /*! \internal \brief Create a module_config objec */
-static void \*module_config_alloc(void)
+static void *module_config_alloc(void)
 {
- struct module_config \*cfg;
+ struct module_config *cfg;
 
- if (!(cfg = ao2_alloc(sizeof(\*cfg), module_config_destructor))) {
+ if (!(cfg = ao2_alloc(sizeof(*cfg), module_config_destructor))) {
  return NULL;
  }
- if (!(cfg->general = ao2_alloc(sizeof(\*cfg->general), NULL))) {
+ if (!(cfg->general = ao2_alloc(sizeof(*cfg->general), NULL))) {
  ao2_ref(cfg, -1);
  return NULL;
  }
@@ -497,9 +497,9 @@ static void \*module_config_alloc(void)
 }
 
 /*! \internal \brief Dispose of a module_config objec */
-static void module_config_destructor(void \*obj)
+static void module_config_destructor(void *obj)
 {
- struct module_config \*cfg = obj;
+ struct module_config *cfg = obj;
  ao2_cleanup(cfg->general);
 }
 
@@ -521,7 +521,7 @@ CONFIG_INFO_STANDARD(cfg_info, module_configs, module_config_alloc,
  .files = ACO_FILES(&module_conf),
 );
 
-static struct aco_type \*general_options[] = ACO_TYPES(&general_option);
+static struct aco_type *general_options[] = ACO_TYPES(&general_option);
 
 ```
 
@@ -598,7 +598,7 @@ CReloads and Using the Configuration Information
 /*! \internal \brief Log the current module value */
 static void log_module_values(void)
 {
- RAII_VAR(struct module_config \*, cfg, ao2_global_obj_ref(module_configs), ao2_cleanup);
+ RAII_VAR(struct module_config *, cfg, ao2_global_obj_ref(module_configs), ao2_cleanup);
 
  if (!cfg || !cfg->general) {
  ast_log(LOG_ERROR, "Rut roh - something blew away our configuration!);
@@ -670,7 +670,7 @@ struct global_options {
  * other items in this struct
  */
 struct module_config {
- struct global_options \*general; /*< Our global setting */
+ struct global_options *general; /*< Our global setting */
 };
 
 /*! \brief A container that holds our global module configuratio */
@@ -686,8 +686,8 @@ static struct aco_type general_option = {
  .category_match = ACO_WHITELIST,
 };
 
-static void \*module_config_alloc(void);
-static void module_config_destructor(void \*obj);
+static void *module_config_alloc(void);
+static void module_config_destructor(void *obj);
 
 /*! \brief A configuration file that will be processed for the modul */
 static struct aco_file module_conf = {
@@ -699,17 +699,17 @@ CONFIG_INFO_STANDARD(cfg_info, module_configs, module_config_alloc,
  .files = ACO_FILES(&module_conf),
 );
 
-static struct aco_type \*general_options[] = ACO_TYPES(&general_option);
+static struct aco_type *general_options[] = ACO_TYPES(&general_option);
 
 /*! \internal \brief Create a module_config objec */
-static void \*module_config_alloc(void)
+static void *module_config_alloc(void)
 {
- struct module_config \*cfg;
+ struct module_config *cfg;
 
- if (!(cfg = ao2_alloc(sizeof(\*cfg), module_config_destructor))) {
+ if (!(cfg = ao2_alloc(sizeof(*cfg), module_config_destructor))) {
  return NULL;
  }
- if (!(cfg->general = ao2_alloc(sizeof(\*cfg->general), NULL))) {
+ if (!(cfg->general = ao2_alloc(sizeof(*cfg->general), NULL))) {
  ao2_ref(cfg, -1);
  return NULL;
  }
@@ -718,16 +718,16 @@ static void \*module_config_alloc(void)
 }
 
 /*! \internal \brief Dispose of a module_config objec */
-static void module_config_destructor(void \*obj)
+static void module_config_destructor(void *obj)
 {
- struct module_config \*cfg = obj;
+ struct module_config *cfg = obj;
  ao2_cleanup(cfg->general);
 }
 
 /*! \internal \brief Log the current module value */
 static void log_module_values(void)
 {
- RAII_VAR(struct module_config \*, cfg, ao2_global_obj_ref(module_configs), ao2_cleanup);
+ RAII_VAR(struct module_config *, cfg, ao2_global_obj_ref(module_configs), ao2_cleanup);
 
  if (!cfg || !cfg->general) {
  ast_log(LOG_ERROR, "Rut roh - something blew away our configuration!");

--- a/docs/Development/Reference-Information/Other-Reference-Information/Alembic-Scripts.md
+++ b/docs/Development/Reference-Information/Other-Reference-Information/Alembic-Scripts.md
@@ -19,7 +19,7 @@ AST_BOOL_VALUES = [ '0', '1',
  'false', 'true',
  'no', 'yes' ]
 def upgrade():
- ast_bool_values = ENUM(\*AST_BOOL_VALUES, name=AST_BOOL_NAME, create_type=False)
+ ast_bool_values = ENUM(*AST_BOOL_VALUES, name=AST_BOOL_NAME, create_type=False)
  op.add_column('ps_aors', sa.Column('remove_unavailable', ast_bool_values))
 
 ```

--- a/docs/Development/Reference-Information/Other-Reference-Information/Build-System-Architecture.md
+++ b/docs/Development/Reference-Information/Other-Reference-Information/Build-System-Architecture.md
@@ -62,7 +62,7 @@ Add `LIBNAME_LIB` and `LIBNAME_INCLUDE` lines into this file. The configure scri
 Modules that have a dependency must have a special comment block in them that is used by the build system.
 
 ```
-/*\*\* MODULEINFO
+/*** MODULEINFO
  <depend>libname</depend>
     * */
 

--- a/docs/Development/Roadmap/Asterisk-10-Projects/Media-Architecture-Proposal.md
+++ b/docs/Development/Roadmap/Asterisk-10-Projects/Media-Architecture-Proposal.md
@@ -83,7 +83,7 @@ enum ast_format_cmp_res {
  * \return Pointer to ast_format object, same pointer that is passed in
  * by the first argument.
  */
-struct ast_format \*ast_format_set(struct ast_format \*format, enum ast_format_id id, int set_attributes, ... );
+struct ast_format *ast_format_set(struct ast_format *format, enum ast_format_id id, int set_attributes, ... );
 
 /*!
  * \brief This function is used to set an ast_format object to represent a media format
@@ -95,14 +95,14 @@ struct ast_format \*ast_format_set(struct ast_format \*format, enum ast_format_i
  * \return 0, The format key value pairs are within the capabilities defined in this structure.
  * \return -1, The format key value pairs are _NOT_ within the capabilities of this structure.
  */
-int ast_format_isset(struct ast_format \*format, ... );
+int ast_format_isset(struct ast_format *format, ... );
 
 /*!
  * \brief Compare ast_formats structures
  *
  * \retval ast_format_cmp_res representing the result of comparing format1 and format2.
  */
-enum ast_format_cmp_res ast_format_cmp(struct ast_format \*format1, struct ast_format \*format2);
+enum ast_format_cmp_res ast_format_cmp(struct ast_format *format1, struct ast_format *format2);
 
 /*!
  * \brief Find joint format attributes of two ast_format
@@ -112,12 +112,12 @@ enum ast_format_cmp_res ast_format_cmp(struct ast_format \*format1, struct ast_f
  * retval 0, joint attribute capabilities exist.
  * retval -1, no joint attribute capabilities exist.
  */
-int ast_format_joint(struct ast_format \*format1, struct ast_format \*format2, struct ast_format \*result);
+int ast_format_joint(struct ast_format *format1, struct ast_format *format2, struct ast_format *result);
 
 /*!
  * \brief copy format src into format dst.
  */
-void ast_format_copy(struct ast_format \*src, struct ast_format \*dst);
+void ast_format_copy(struct ast_format *src, struct ast_format *dst);
 
 /*!
  * \brief ast_format to iax2 bitfield format represenatation
@@ -127,7 +127,7 @@ void ast_format_copy(struct ast_format \*src, struct ast_format \*dst);
  * \retval iax2 representation of ast_format
  * \retval 0, if no representation existis for iax2
  */
-uint64_t ast_format_to_iax2(struct ast_format \*format);
+uint64_t ast_format_to_iax2(struct ast_format *format);
 
 /*!
  * \brief convert iax2 bitfield format to ast_format represenatation
@@ -136,7 +136,7 @@ uint64_t ast_format_to_iax2(struct ast_format \*format);
  * \retval on success, pointer to the dst format in the input parameters
  * \retval on failure, NULL
  */
-struct ast_format \*ast_format_from_iax2(uint64_t src, struct ast_format \*dst);
+struct ast_format *ast_format_from_iax2(uint64_t src, struct ast_format *dst);
 
 ```
 
@@ -164,18 +164,18 @@ struct ast_format_attr_interface {
  *
  * \retval ast_format_cmp_res representing the result of comparing fattr1 and fattr2.
  */
- enum ast_format_cmp_res (\* const format_attr_cmp)(struct ast_format_attr \*fattr1, struct ast_format_attr \*fattr2);
+ enum ast_format_cmp_res (* const format_attr_cmp)(struct ast_format_attr *fattr1, struct ast_format_attr *fattr2);
 
  /*! \brief Get joint attributes of same format type if they exist.
  *
  * \retval 0 if joint attributes exist
  * \retval -1 if no joint attributes are present
  */
- int (\* const format_attr_get_joint)(struct ast_format_attr \*fattr1, struct ast_format_attr \*fattr2, struct ast_format_attr \*result);
+ int (* const format_attr_get_joint)(struct ast_format_attr *fattr1, struct ast_format_attr *fattr2, struct ast_format_attr *result);
 
  /*! \brief Set format capabilities from a list of key value pairs ending with AST_FORMAT_ATTR_END.
  * \note This function is expected to call va_end(ap) after processing the va_list */
- void (\* const format_attr_set)(struct ast_format_attr \*format_attr, va_list ap);
+ void (* const format_attr_set)(struct ast_format_attr *format_attr, va_list ap);
 };
 
 /*! \brief register ast_format_attr_interface with core.
@@ -183,7 +183,7 @@ struct ast_format_attr_interface {
  * \retval 0 success
  * \retval -1 failure
  */
-int ast_format_attr_reg_interface(struct ast_format_attr_interface \*interface);
+int ast_format_attr_reg_interface(struct ast_format_attr_interface *interface);
 
 /*!
  * \brief unregister format_attr interface with core.
@@ -191,7 +191,7 @@ int ast_format_attr_reg_interface(struct ast_format_attr_interface \*interface);
  * \retval 0 success
  * \retval -1 failure
  */
-int ast_format_attr_unreg_interface(struct ast_format_attr_interface \*interface);
+int ast_format_attr_unreg_interface(struct ast_format_attr_interface *interface);
 
 ```
 
@@ -228,9 +228,9 @@ Since the number of formats that can be represented will likely never be exhaust
 
 /* ALL FORMAT CATEGORIE */
 enum ast_format_type {
- AST_FORMAT_TYPE_AUDIO = 1 \* FORMAT_INC,
- AST_FORMAT_TYPE_VIDEO = 2 \* FORMAT_INC,
- AST_FORMAT_TYPE_IMAGE = 3 \* FORMAT_INC,
+ AST_FORMAT_TYPE_AUDIO = 1 * FORMAT_INC,
+ AST_FORMAT_TYPE_VIDEO = 2 * FORMAT_INC,
+ AST_FORMAT_TYPE_IMAGE = 3 * FORMAT_INC,
 };
 
 enum ast_format_id {
@@ -246,7 +246,7 @@ enum ast_format_id {
 };
 
 /* Determine what category a format type is i */
-#define AST_FORMAT_GET_TYPE(format) (((unsigned int) (format->uid / AST_FORMAT_INC)) \* AST_FORMAT_INC)
+#define AST_FORMAT_GET_TYPE(format) (((unsigned int) (format->uid / AST_FORMAT_INC)) * AST_FORMAT_INC)
 
 ```
 ## New Format Representation Code Examples and Use cases.
@@ -402,7 +402,7 @@ jointcapabilties = peer->capability & remote_capability
 ```
 ```
 /*---NEW: Peer and remote capabilities are ast_cap objects. */
-struct ast_cap \*jointcapabilities;
+struct ast_cap *jointcapabilities;
 
 ast_cap_add(peer->capability, ast_format_set(&tmp, AST_FORMAT_ULAW));
 ast_cap_add(peer->capability, ast_format_set(&tmp, AST_FORMAT_GSM));
@@ -455,9 +455,9 @@ format_t text_capabilities = capabilities & AST_FORMAT_TEXT_MASK;
 ```
 ```
 /*---NEW: Separate media types are returned on a new capabilities structure using ast_cap_get_type() */
-struct ast_cap \*video = ast_cap_get_type(capabilities, AST_FORMAT_TYPE_AUDIO);
-struct ast_cap \*voice = ast_cap_get_type(capabilities, AST_FORMAT_TYPE_VIDEO);
-struct ast_cap \*text = ast_cap_get_type(capabilities, AST_FORMAT_TYPE_TEXT);
+struct ast_cap *video = ast_cap_get_type(capabilities, AST_FORMAT_TYPE_AUDIO);
+struct ast_cap *voice = ast_cap_get_type(capabilities, AST_FORMAT_TYPE_VIDEO);
+struct ast_cap *text = ast_cap_get_type(capabilities, AST_FORMAT_TYPE_TEXT);
 
 ```
 ## Ast Format Capability API Defined
@@ -471,13 +471,13 @@ struct ast_cap;
  * \retval ast_cap object on success.
  * \retval NULL on failure.
  */
-struct ast_cap \*ast_cap_alloc(void);
+struct ast_cap *ast_cap_alloc(void);
 
 /*! \brief Destroy an ast_cap structure.
  *
  * \return NULL
  */
-void \*ast_cap_destroy(struct ast_cap \*cap);
+void *ast_cap_destroy(struct ast_cap *cap);
 
 /*! \brief Add format capability to capabilities structure.
  *
@@ -485,7 +485,7 @@ void \*ast_cap_destroy(struct ast_cap \*cap);
  * what is placed in the ast_cap structure. The actual
  * input format ptr is not stored.
  */
-void ast_cap_add(struct ast_cap \*cap, struct ast_format \*format);
+void ast_cap_add(struct ast_cap *cap, struct ast_format *format);
 
 /*! \brief Remove format capability from capability structure.
  *
@@ -495,7 +495,7 @@ void ast_cap_add(struct ast_cap \*cap, struct ast_format \*format);
  * \retval 0, remove was successful
  * \retval -1, remove failed. Could not find format to remove
  */
-int ast_cap_remove(struct ast_cap \*cap, struct ast_format \*format);
+int ast_cap_remove(struct ast_cap *cap, struct ast_format *format);
 
 /*! \brief Remove all format capabilities from capability
  * structure for a specific format id.
@@ -506,31 +506,31 @@ int ast_cap_remove(struct ast_cap \*cap, struct ast_format \*format);
  * \retval 0, remove was successful
  * \retval -1, remove failed. Could not find formats to remove
  */
-int ast_cap_remove_byid(struct ast_cap \*cap, enum ast_format_id id);
+int ast_cap_remove_byid(struct ast_cap *cap, enum ast_format_id id);
 
 /*! \brief Find if ast_format is within the capabilities of the ast_cap object.
  *
  * retval 1 format is compatible with formats held in ast_cap object.
  * retval 0 format is not compatible with any formats in ast_cap object.
  */
-int ast_cap_iscompatible(struct ast_cap \*cap, struct ast_format \*format);
+int ast_cap_iscompatible(struct ast_cap *cap, struct ast_format *format);
 
 /*! \brief Get joint capability structure.
  *
  * \retval !NULL success
  * \retval NULL failure
  */
-struct ast_cap \*ast_cap_joint(struct ast_cap \*cap1, struct ast_cap \*cap2);
+struct ast_cap *ast_cap_joint(struct ast_cap *cap1, struct ast_cap *cap2);
 
 /*! \brief Get all capabilities for a specific media type
  *
  * \retval !NULL success
  * \retval NULL failure
  */
-struct ast_cap \*ast_cap_get_type(struct ast_cap \*cap, enum ast_format_type ftype);
+struct ast_cap *ast_cap_get_type(struct ast_cap *cap, enum ast_format_type ftype);
 
 /*! \brief Start iterating format */
-void ast_cap_iter_start(struct ast_cap \*cap);
+void ast_cap_iter_start(struct ast_cap *cap);
 
 /*! \brief Next format in interation
  *
@@ -552,12 +552,12 @@ void ast_cap_iter_start(struct ast_cap \*cap);
  * \retval 0 on success, new format is copied into input format struct
  * \retval -1, no more formats are present.
  */
-int ast_cap_iter_next(struct ast_cap \*cap, struct ast_format \*format);
+int ast_cap_iter_next(struct ast_cap *cap, struct ast_format *format);
 
 /*! \brief Ends ast_cap iteration.
  * \note this must be call after every ast_cap_iter_start
  */
-void ast_cap_iter_end(struct ast_cap \*cap);
+void ast_cap_iter_end(struct ast_cap *cap);
 
 /*!
  * \brief ast_cap to iax2 bitfield format represenatation
@@ -567,13 +567,13 @@ void ast_cap_iter_end(struct ast_cap \*cap);
  * \retval iax2 representation of ast_cap
  * \retval 0, if no iax2 capabilities are present in ast_cap
  */
-uint64_t ast_cap_to_iax2(struct ast_cap \*cap);
+uint64_t ast_cap_to_iax2(struct ast_cap *cap);
 
 /*!
  * \brief convert iax2 bitfield format to ast_cap represenatation
  * \note This is only to be used for IAX2 compatibility 
  */
-void ast_cap_from_iax2(uint64_t src, struct ast_cap \*dst);
+void ast_cap_from_iax2(uint64_t src, struct ast_cap *dst);
 
 ```
 
@@ -780,7 +780,7 @@ static struct ast_translator lin16tog722 = {
  .framein = lintog722_framein,
  .sample = slin16_sample,
  .desc_size = sizeof(struct g722_encoder_pvt),
- .buffer_samples = BUFFER_SAMPLES \* 2,
+ .buffer_samples = BUFFER_SAMPLES * 2,
  .buf_size = BUFFER_SAMPLES,
 };
 
@@ -887,8 +887,8 @@ struct ast_channel_stream {
  /*! represents the stream typ */
  enum ast_channel_stream_id id;
 
- struct ast_trans_pvt \*writetrans;
- struct ast_trans_pvt \*readtrans;
+ struct ast_trans_pvt *writetrans;
+ struct ast_trans_pvt *readtrans;
 
  struct ast_cap nativeformats;
 
@@ -915,23 +915,23 @@ enum ast_channel_stream_id {
  */
 }
 
-void ast_channel_init_write_format(struct ast_channel \*chan, enum ast_channel_stream_id id, struct ast_format \*format)
+void ast_channel_init_write_format(struct ast_channel *chan, enum ast_channel_stream_id id, struct ast_format *format)
 
-void ast_channel_init_read_format(struct ast_channel \*chan, enum ast_channel_stream_id id, struct ast_format \*format)
+void ast_channel_init_read_format(struct ast_channel *chan, enum ast_channel_stream_id id, struct ast_format *format)
 
-void ast_channel_set_native_cap(struct ast_channel \*chan, enum ast_channel_stream_id id, struct ast_cap \*cap)
+void ast_channel_set_native_cap(struct ast_channel *chan, enum ast_channel_stream_id id, struct ast_cap *cap)
 
-int ast_channel_copy_readwrite_format(struct ast_channel \*chan1, struct ast_channel \*chan2, enum ast_channel_stream_id id)
+int ast_channel_copy_readwrite_format(struct ast_channel *chan1, struct ast_channel *chan2, enum ast_channel_stream_id id)
 
-void ast_channel_set_read_format(struct ast_channel \*chan, enum ast_channel_stream_id id, struct ast_format \*format)
+void ast_channel_set_read_format(struct ast_channel *chan, enum ast_channel_stream_id id, struct ast_format *format)
 
-void ast_channel_set_write_format(struct ast_channel \*chan, enum ast_channel_stream_id id, struct ast_format \*format)
+void ast_channel_set_write_format(struct ast_channel *chan, enum ast_channel_stream_id id, struct ast_format *format)
 
-int ast_channel_get_native_cap(struct ast_channel \*chan, enum ast_channel_stream_id id, struct ast_cap \*result)
+int ast_channel_get_native_cap(struct ast_channel *chan, enum ast_channel_stream_id id, struct ast_cap *result)
 
-int ast_channel_get_write_format(struct ast_channel \*chan, enum ast_channel_stream_id id, struct ast_format \*result)
+int ast_channel_get_write_format(struct ast_channel *chan, enum ast_channel_stream_id id, struct ast_format *result)
 
-int ast_channel_get_read_format(struct ast_channel \*chan, enum ast_channel_stream_id id, struct ast_format \*result)
+int ast_channel_get_read_format(struct ast_channel *chan, enum ast_channel_stream_id id, struct ast_format *result)
 
 ```
 

--- a/docs/Development/Roadmap/Asterisk-11-Projects/AMI-Event-Documentation.md
+++ b/docs/Development/Roadmap/Asterisk-11-Projects/AMI-Event-Documentation.md
@@ -48,7 +48,7 @@ Example output of both commands is shown below.
 
 ```
 
-\*CLI> manager show events
+*CLI> manager show events
 Events:
  -------------------- -------------------- -------------------- 
  AgentCalled AgentComplete AgentConnect 
@@ -65,7 +65,7 @@ Events:
 ```
 ```
 
-\*CLI> manager show event Dial
+*CLI> manager show event Dial
 Event: Dial
 [Synopsis]
 Raised when a dial action has started.
@@ -109,7 +109,7 @@ SubEvent
  A sub event type, specifying whether or not the dial action has begun
  or ended.
 
-\*CLI> 
+*CLI> 
 
 ```
 
@@ -127,7 +127,7 @@ AMI Event documentation behaves a bit differently then other Asterisk documentat
 
 ```
 
- /*\*\* DOCUMENTATION
+ /*** DOCUMENTATION
  <managerEventInstance>
  <synopsis>Raised when a dial action has ended.</synopsis>
  <syntax>
@@ -149,7 +149,7 @@ AMI Event documentation behaves a bit differently then other Asterisk documentat
 
 ```
 
- /*\*\* DOCUMENTATION
+ /*** DOCUMENTATION
  <managerEventInstance>
  <synopsis>Raised when a dial action has started.</synopsis>
  <syntax>
@@ -164,7 +164,7 @@ AMI Event documentation behaves a bit differently then other Asterisk documentat
  </managerEventInstance>
     * */
 ...
- /*\*\* DOCUMENTATION
+ /*** DOCUMENTATION
  <managerEventInstance>
  <synopsis>Raised when a dial action has ended.</synopsis>
  <syntax>
@@ -181,7 +181,7 @@ AMI Event documentation behaves a bit differently then other Asterisk documentat
 
 ```
 
- /*\*\* DOCUMENTATION
+ /*** DOCUMENTATION
  <managerEventInstance>
  <synopsis>Raised when a dial action has ended.</synopsis>
  <syntax>
@@ -194,7 +194,7 @@ AMI Event documentation behaves a bit differently then other Asterisk documentat
 
 Is equivalent to:
 
- /*\*\* DOCUMENTATION
+ /*** DOCUMENTATION
  <managerEventInstance>
  <synopsis>Raised when a dial action has ended.</synopsis>
  <parameter name="DialStatus">
@@ -216,7 +216,7 @@ The following are the changes to the XML DTD schema used to validate the generat
  <!ATTLIST managerEvent name CDATA #REQUIRED>
  <!ATTLIST managerEvent language CDATA #REQUIRED>
 
- <!ELEMENT managerEventInstance (synopsis?,syntax?,description?,see-also?)\*>
+ <!ELEMENT managerEventInstance (synopsis?,syntax?,description?,see-also?)*>
  <!ATTLIST managerEventInstance class CDATA #REQUIRED>
 
 ```
@@ -271,7 +271,7 @@ Source Comments
 
 ```
 
-/*\*\* DOCUMENTATION
+/*** DOCUMENTATION
 ....
     * */
 

--- a/docs/Development/Roadmap/Asterisk-11-Projects/Configuration-parsing-with-the-Config-Options-API.md
+++ b/docs/Development/Roadmap/Asterisk-11-Projects/Configuration-parsing-with-the-Config-Options-API.md
@@ -58,21 +58,21 @@ static AO2_GLOBAL_OBJ_STATIC(globals);
 ```
 C
 struct my_config {
- struct my_global_cfg \*global;
- struct ao2_container \*items;
+ struct my_global_cfg *global;
+ struct ao2_container *items;
 };
 
-static void my_config_destructor(void \*obj)
+static void my_config_destructor(void *obj)
 {
- struct my_config \*cfg = obj;
+ struct my_config *cfg = obj;
  ao2_cleanup(cfg->global);
  ao2_cleanup(cfg->items);
 }
 
-static void \*my_config_alloc(void)
+static void *my_config_alloc(void)
 {
- struct my_config \*cfg;
- if (!(cfg = ao2_alloc(sizeof(\*cfg), my_config_destructor))) {
+ struct my_config *cfg;
+ if (!(cfg = ao2_alloc(sizeof(*cfg), my_config_destructor))) {
  return NULL;
  }
  if (!(cfg->global = my_global_cfg_alloc())) {
@@ -160,8 +160,8 @@ A completely consistent snapshot of config data can be accessed via
 C
 void some_func_that_accesses_config_data(void)
 {
- RAII_VAR(struct my_config \*, cfg, ao2_global_obj_ref(globals), ao2_cleanup);
- RAII_VAR(struct my_item \*, item, NULL, ao2_cleanup);
+ RAII_VAR(struct my_config *, cfg, ao2_global_obj_ref(globals), ao2_cleanup);
+ RAII_VAR(struct my_item *, item, NULL, ao2_cleanup);
  if (!cfg) {
  return;
  }

--- a/docs/Development/Roadmap/Asterisk-11-Projects/Unique-Call-ID-Logging.md
+++ b/docs/Development/Roadmap/Asterisk-11-Projects/Unique-Call-ID-Logging.md
@@ -96,7 +96,7 @@ cpp
  * \note The newly created callid will be referenced upon creation and this function should be
  * paired with a call to ast_callid_deref()
  */
-struct ast_callid \*ast_create_callid();
+struct ast_callid *ast_create_callid();
 
 /*!
  * \brief Increase callid reference count
@@ -114,7 +114,7 @@ struct ast_callid \*ast_create_callid();
  *
  * \retval NULL always
  */
-#define ast_callid_unref(c) ({ ao2_ref(c, -1); (struct ast_channel \*) (NULL); )}
+#define ast_callid_unref(c) ({ ao2_ref(c, -1); (struct ast_channel *) (NULL); )}
 
 /*!
  * \brief Adds a known callid to thread storage of the calling thread
@@ -123,7 +123,7 @@ struct ast_callid \*ast_create_callid();
  * \retval 0 - success
  * \retval 1 - failure due to thread already being bound to a callid
  */
-int ast_callid_threadassoc_add(struct ast_callid \*callid);
+int ast_callid_threadassoc_add(struct ast_callid *callid);
 
 ```
 

--- a/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-API-Improvements/Stasis-Message-Bus/Using-the-Stasis-Message-Bus/Stasis-Subscriber-Shutdown-Problem.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-API-Improvements/Stasis-Message-Bus/Using-the-Stasis-Message-Bus/Stasis-Subscriber-Shutdown-Problem.md
@@ -25,24 +25,24 @@ Bad code we all wrote at first
 struct ast_foo {
  /* foo's stuff */
  /*! Very important subscriptio */
- struct stasis_subscription \*sub;
+ struct stasis_subscription *sub;
 };
-static void foo_dtor(void \*obj) {
- struct ast_foo \*foo = obj;
+static void foo_dtor(void *obj) {
+ struct ast_foo *foo = obj;
      stasis_unsubscribe(foo->sub); /* !!! WRONG !! */
      /* destroy foo's stuff */
     }
 
-    static void foo_cb(void \*data, struct stasis_subscription \*sub,
-     struct stasis_topic \*topic, struct stasis_message \*message)
+    static void foo_cb(void *data, struct stasis_subscription *sub,
+     struct stasis_topic *topic, struct stasis_message *message)
     {
-     struct foo \*foo = data;
+     struct foo *foo = data;
      /* Message handlin */
     }
 
-    struct ast_foo \*ast_foo_create(void) {
-     RAII_VAR(struct ast_foo \*, foo, NULL, ao2_cleanup);
-     foo = ao2_alloc(sizeof(\*foo), foo_dtor);
+    struct ast_foo *ast_foo_create(void) {
+     RAII_VAR(struct ast_foo *, foo, NULL, ao2_cleanup);
+     foo = ao2_alloc(sizeof(*foo), foo_dtor);
      if (!foo) { return NULL; }
      foo->sub = stasis_subscribe(some_topic(), foo_cb, foo);
      if (!foo->sub) { return NULL; }
@@ -70,17 +70,17 @@ static void foo_dtor(void \*obj) {
     struct ast_foo {
      /* foo's stuff */
      /*! Very important subscriptio */
-     struct stasis_subscription \*sub;
+     struct stasis_subscription *sub;
     };
-    static void foo_dtor(void \*obj) {
-     struct ast_foo \*foo = obj;
+    static void foo_dtor(void *obj) {
+     struct ast_foo *foo = obj;
      stasis_unsubscribe(foo->sub); /* !!! STILL WRONG !! */
      /* destroy foo's stuff */
     }
-    static void foo_cb(void \*data, struct stasis_subscription \*sub,
-     struct stasis_topic \*topic, struct stasis_message \*message)
+    static void foo_cb(void *data, struct stasis_subscription *sub,
+     struct stasis_topic *topic, struct stasis_message *message)
     {
-     struct foo \*foo = data;
+     struct foo *foo = data;
      /* Now we have to clean up the reference on the final messag */
      if (stasis_subscription_final_message(sub, message)) {
      ao2_cleanup(foo);
@@ -88,9 +88,9 @@ static void foo_dtor(void \*obj) {
      }
      /* Message handlin */
     }
-    struct ast_foo \*ast_foo_create(void) {
-     RAII_VAR(struct ast_foo \*, foo, NULL, ao2_cleanup);
-     foo = ao2_alloc(sizeof(\*foo), foo_dtor);
+    struct ast_foo *ast_foo_create(void) {
+     RAII_VAR(struct ast_foo *, foo, NULL, ao2_cleanup);
+     foo = ao2_alloc(sizeof(*foo), foo_dtor);
      if (!foo) { return NULL; }
      foo->sub = stasis_subscribe(some_topic(), foo_cb, foo);
      if (!foo->sub) { return NULL; }
@@ -119,17 +119,17 @@ static void foo_dtor(void \*obj) {
     struct ast_foo {
      /* foo's stuff */
      /*! Very important subscriptio */
-     struct stasis_subscription \*sub;
+     struct stasis_subscription *sub;
     };
-    static void foo_dtor(void \*obj) {
-     struct ast_foo \*foo = obj;
+    static void foo_dtor(void *obj) {
+     struct ast_foo *foo = obj;
      /* destroy foo's stuff */
      printf("%p\n", foo);
     }
-    static void foo_cb(void \*data, struct stasis_subscription \*sub,
-     struct stasis_topic \*topic, struct stasis_message \*message)
+    static void foo_cb(void *data, struct stasis_subscription *sub,
+     struct stasis_topic *topic, struct stasis_message *message)
     {
-     struct ast_foo \*foo = data;
+     struct ast_foo *foo = data;
      if (stasis_subscription_final_message(sub, message)) {
      /* Last message; all don */
      ao2_cleanup(foo);
@@ -137,20 +137,20 @@ static void foo_dtor(void \*obj) {
      }
      /* Message handlin */
     }
-    struct ast_foo \*ast_foo_create(void) {
-     RAII_VAR(struct ast_foo \*, foo, NULL, ao2_cleanup);
-     foo = ao2_alloc(sizeof(\*foo), foo_dtor);
+    struct ast_foo *ast_foo_create(void) {
+     RAII_VAR(struct ast_foo *, foo, NULL, ao2_cleanup);
+     foo = ao2_alloc(sizeof(*foo), foo_dtor);
      if (!foo) { return NULL; }
      foo->sub = stasis_subscribe(some_topic(), foo_cb, foo);
      if (!foo->sub) { return NULL; }
      /* This is the reference the subscription ha */
      ao2_ref(foo, +1);
      /* We're not bumping the refcount, since the caller doesn't
-     \* get a direct reference. The call ast_foo_shutdown() instead
+     * get a direct reference. The call ast_foo_shutdown() instead
     */
      return foo;
     }
-    void ast_foo_shutdown(struct ast_foo \*foo) {
+    void ast_foo_shutdown(struct ast_foo *foo) {
      if (!foo) { return; }
      stasis_unsubscribe(foo->sub);
     }

--- a/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-API-Improvements/Stasis-Message-Bus/Using-the-Stasis-Message-Bus/index.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-API-Improvements/Stasis-Message-Bus/Using-the-Stasis-Message-Bus/index.md
@@ -23,8 +23,8 @@ Plain subscriptions
 A regular subscription is Stasis is created by using the [stasis_subscribe()](http://doxygen.asterisk.org/trunk/dd/d79/stasis_8h.html#0f22205d00ef47310681da71d082017b) function. You provide the topic, a callback function, and a piece of data you wish to come along with the callback, and the message bus does the rest.
 
 ```
-static void statsmaker(void \*data, struct stasis_subscription \*sub,
- struct stasis_topic \*topic, struct stasis_message \*message)
+static void statsmaker(void *data, struct stasis_subscription *sub,
+ struct stasis_topic *topic, struct stasis_message *message)
 {
  /* .. */
 }
@@ -64,10 +64,10 @@ You have some really strong guarantees about how the messages get dispatched to 
 The bulk of the subscription callback will be whatever logic you need to process the incoming messages. But there is one caveat: [handling the final message](/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-API-Improvements/Stasis-Message-Bus/Using-the-Stasis-Message-Bus/Stasis-Subscriber-Shutdown-Problem).
 
 ```
-static void statsmaker(void \*data, struct stasis_subscription \*sub,
- struct stasis_topic \*topic, struct stasis_message \*message)
+static void statsmaker(void *data, struct stasis_subscription *sub,
+ struct stasis_topic *topic, struct stasis_message *message)
 {
- RAII_VAR(struct ast_str \*, metric, NULL, ast_free);
+ RAII_VAR(struct ast_str *, metric, NULL, ast_free);
  if (stasis_subscription_final_message(sub, message)) {
  /* Normally, data points to an object that must be cleaned up.
  * The final message is an unsubscribe notification that's
@@ -97,18 +97,18 @@ Message Routing
 We discovered in using subscriptions that most subscription handlers were simply chains of `if/else` clauses dispatching messages based on type. Rather than encourage that sort of ugly boilerplate, we introduced the [stasis_message_router](http://doxygen.asterisk.org/trunk/d4/d25/stasis__message__router_8h.html).
 
 ```
-static void updates(void \*data, struct stasis_subscription \*sub,
- struct stasis_topic \*topic, struct stasis_message \*message)
+static void updates(void *data, struct stasis_subscription *sub,
+ struct stasis_topic *topic, struct stasis_message *message)
 {
  /* Since this came from a message router, we know the type of the
  * message. We can cast the data without checking its type.
  */
- struct stasis_cache_update \*update = stasis_message_data(message);
+ struct stasis_cache_update *update = stasis_message_data(message);
  /* .. */
 
 }
-static void default_route(void \*data, struct stasis_subscription \*sub,
- struct stasis_topic \*topic, struct stasis_message \*message)
+static void default_route(void *data, struct stasis_subscription *sub,
+ struct stasis_topic *topic, struct stasis_message *message)
 {
  if (stasis_subscription_final_message(sub, message)) {
  /* subscription cleanu */

--- a/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-API-Improvements/Stasis-Message-Bus/index.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-API-Improvements/Stasis-Message-Bus/index.md
@@ -91,12 +91,12 @@ struct ast_foo {
 };
 
 /*! \brief Message type for \ref ast_fo */
-struct stasis_message_type \*ast_foo_type(void);
+struct stasis_message_type *ast_foo_type(void);
 
 /*!
  * \brief Topic for the foo module.
  */
-struct stasis_topic \*ast_foo_topic(void);
+struct stasis_topic *ast_foo_topic(void);
 
 ```
 ```
@@ -109,16 +109,16 @@ ASTERISK_FILE_VERSION(__FILE__, "$Revision$")
 #include "asterisk/stasis.h"
 #include "foo.h"
 
-static struct stasis_message_type \*foo_type;
+static struct stasis_message_type *foo_type;
 
-struct stasis_topic \*foo_topic;
+struct stasis_topic *foo_topic;
 
-struct stasis_message_type \*ast_foo_type(void)
+struct stasis_message_type *ast_foo_type(void)
 {
  return foo_type;
 }
 
-struct stasis_topic \*ast_foo_topic(void)
+struct stasis_topic *ast_foo_topic(void)
 {
  return foo_topic;
 }
@@ -127,9 +127,9 @@ struct stasis_topic \*ast_foo_topic(void)
  * \brief Convenience function to publish an \ref ast_foo message to the
  * \ref foo_topic.
  */
-static void publish_foo(struct ast_foo \*foo)
+static void publish_foo(struct ast_foo *foo)
 {
- RAII_VAR(struct stasis_message \*, msg, NULL, ao2_cleanup);
+ RAII_VAR(struct stasis_message *, msg, NULL, ao2_cleanup);
 
  msg = stasis_message_create(foo_type, foo);
 
@@ -183,12 +183,12 @@ AST_MODULE_INFO(ASTERISK_GPL_KEY, 0, "The wonders of foo",
 #include "foo.h"
 
 struct ast_bar {
- struct stasis_subscription \*sub;
+ struct stasis_subscription *sub;
 };
 
-static void bar_dtor(void \*obj)
+static void bar_dtor(void *obj)
 {
- struct ast_bar \*bar = obj;
+ struct ast_bar *bar = obj;
 
  /* Since the subscription holds a reference, unsubscribe
  * should happen before destruction.
@@ -196,12 +196,12 @@ static void bar_dtor(void \*obj)
  ast_assert(bar->sub == NULL);
 }
 
-static void bar_callback(void \*data,
- struct stasis_subscription \*sub,
- struct stasis_topic \*topic,
- struct stasis_message \*message)
+static void bar_callback(void *data,
+ struct stasis_subscription *sub,
+ struct stasis_topic *topic,
+ struct stasis_message *message)
 {
- struct ast_bar \*bar = data;
+ struct ast_bar *bar = data;
 
  if (stasis_subscription_final_message(sub, message)) {
  /* Final message; we can clean ourselves u */
@@ -210,19 +210,19 @@ static void bar_callback(void \*data,
  }
 
  if (ast_foo_type() == stasis_message_type(message)) {
- struct ast_foo \*foo = stasis_message_data(message);
+ struct ast_foo *foo = stasis_message_data(message);
  /* A fooing we will go.. */
  } else if (ast_whatever_type() == stasis_message_type(message)) {
- struct ast_whatever \*whatever = stasis_message_data (message);
+ struct ast_whatever *whatever = stasis_message_data (message);
  /* whateve */
  }
 }
 
-struct ast_bar \*ast_bar_create(void)
+struct ast_bar *ast_bar_create(void)
 {
- RAII_VAR(struct ast_bar \*, bar, NULL, ao2_cleanup);
+ RAII_VAR(struct ast_bar *, bar, NULL, ao2_cleanup);
 
- bar = ao2_alloc(sizeof(\*bar), bar_dtor);
+ bar = ao2_alloc(sizeof(*bar), bar_dtor);
  if (!bar) {
  return NULL;
  }
@@ -238,7 +238,7 @@ struct ast_bar \*ast_bar_create(void)
  return bar;
 }
 
-void ast_bar_shutdown(struct ast_bar \*bar)
+void ast_bar_shutdown(struct ast_bar *bar)
 {
  if (!bar) {
  return NULL;
@@ -258,12 +258,12 @@ void ast_bar_shutdown(struct ast_bar \*bar)
 #include "foo.h"
 
 struct ast_bar {
- struct stasis_message_router \*router;
+ struct stasis_message_router *router;
 };
 
-static void bar_dtor(void \*obj)
+static void bar_dtor(void *obj)
 {
- struct ast_bar \*bar = obj;
+ struct ast_bar *bar = obj;
 
  /* Since the subscription holds a reference, unsubscribe
  * should happen before destruction.
@@ -271,25 +271,25 @@ static void bar_dtor(void \*obj)
  ast_assert(bar->router == NULL);
 }
 
-static void bar_default(void \*data,
- struct stasis_subscription \*sub,
- struct stasis_topic \*topic,
- struct stasis_message \*message)
+static void bar_default(void *data,
+ struct stasis_subscription *sub,
+ struct stasis_topic *topic,
+ struct stasis_message *message)
 {
- struct ast_bar \*bar = data;
+ struct ast_bar *bar = data;
  if (stasis_subscription_final_message(sub, message)) {
  /* Final message; we can clean ourselves u */
  ao2_cleanup(bar);
  }
 }
 
-static void bar_foo(void \*data,
- struct stasis_subscription \*sub,
- struct stasis_topic \*topic,
- struct stasis_message \*message)
+static void bar_foo(void *data,
+ struct stasis_subscription *sub,
+ struct stasis_topic *topic,
+ struct stasis_message *message)
 {
- struct ast_bar \*bar = data;
- struct ast_foo \*foo;
+ struct ast_bar *bar = data;
+ struct ast_foo *foo;
 
  ast_assert(ast_foo_type() == stasis_message_type(message));
  foo = stasis_message_data(message);
@@ -297,25 +297,25 @@ static void bar_foo(void \*data,
 
 }
 
-static void bar_whatever(void \*data,
- struct stasis_subscription \*sub,
- struct stasis_topic \*topic,
- struct stasis_message \*message)
+static void bar_whatever(void *data,
+ struct stasis_subscription *sub,
+ struct stasis_topic *topic,
+ struct stasis_message *message)
 {
- struct ast_bar \*bar = data;
- struct ast_whatever \*whatever;
+ struct ast_bar *bar = data;
+ struct ast_whatever *whatever;
 
  ast_assert(ast_whatever_type() == stasis_message_type(message));
  whatever = stasis_message_data (message);
  /* whateve */
 }
 
-struct ast_bar \*ast_bar_create(void)
+struct ast_bar *ast_bar_create(void)
 {
- RAII_VAR(struct ast_bar \*, bar, NULL, ao2_cleanup);
+ RAII_VAR(struct ast_bar *, bar, NULL, ao2_cleanup);
  int r;
 
- bar = ao2_alloc(sizeof(\*bar), bar_dtor);
+ bar = ao2_alloc(sizeof(*bar), bar_dtor);
  if (!bar) {
  return NULL;
  }
@@ -345,7 +345,7 @@ struct ast_bar \*ast_bar_create(void)
  return bar;
 }
 
-void ast_bar_shutdown(struct ast_bar \*bar)
+void ast_bar_shutdown(struct ast_bar *bar)
 {
  if (!bar) {
  return;

--- a/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-Bridging-Project/Asterisk-12-Bridging-API.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-Bridging-Project/Asterisk-12-Bridging-API.md
@@ -161,13 +161,13 @@ struct ast_bridge_channel {
  /*! Current bridged channel stat */
  enum ast_bridge_channel_state state;
  /*! Asterisk channel participating in the bridg */
- struct ast_channel \*chan;
+ struct ast_channel *chan;
  /*! Asterisk channel we are swapping with (if swapping */
- struct ast_channel \*swap;
+ struct ast_channel *swap;
  /*! Bridge this channel is participating i */
- struct ast_bridge \*bridge;
+ struct ast_bridge *bridge;
  /*! Private information unique to the bridge technolog */
- void \*bridge_pvt;
+ void *bridge_pvt;
  /*! Thread handling the bridged channe */
  pthread_t thread;
  /*! Additional file descriptors to look a */
@@ -177,12 +177,12 @@ struct ast_bridge_channel {
  /*! TRUE if the imparted channel must wait for an explicit depart from the bridge to reclaim the channel */
  unsigned int depart_wait:1;
  /*! Features structure for features that are specific to this channe */
- struct ast_bridge_features \*features;
+ struct ast_bridge_features *features;
  /*! Technology optimization parameters used by bridging technologies capable of
  * optimizing based upon talk detection */
  struct ast_bridge_tech_optimizations tech_args;
  /*! Call ID associated with bridge channe */
- struct ast_callid \*callid;
+ struct ast_callid *callid;
  /*! Linked list informatio */
  AST_LIST_ENTRY(ast_bridge_channel) entry;
  /*! Queue of actions to perform on the channel */
@@ -201,7 +201,7 @@ For bridges that support video that are in AST_BRIDGE_VIDEO_MODE_SINGLE_SRC mode
  * should be the current single video fee */
 struct ast_bridge_video_single_src_data {
  /*! Only accept video coming from this channe */
- struct ast_channel \*chan_vsrc;
+ struct ast_channel *chan_vsrc;
 };
 
 ```
@@ -216,11 +216,11 @@ For bridges that support video that are in AST_BRIDGE_VIDEO_MODE_TALKER_SRC mode
  * should be the current single video fee */
 struct ast_bridge_video_talker_src_data {
  /*! Only accept video coming from this channe */
- struct ast_channel \*chan_vsrc;
+ struct ast_channel *chan_vsrc;
  int average_talking_energy;
 
  /*! Current talker see's this perso */
- struct ast_channel \*chan_old_vsrc;
+ struct ast_channel *chan_old_vsrc;
 };
 
 ```
@@ -274,21 +274,21 @@ struct ast_bridge {
  /*! Bridge flags to tweak behavio */
  struct ast_flags feature_flags;
  /*! Bridge technology that is handling the bridg */
- struct ast_bridge_technology \*technology;
+ struct ast_bridge_technology *technology;
  /*! Private information unique to the bridge technolog */
- void \*bridge_pvt;
+ void *bridge_pvt;
  /*! Thread running the bridg */
  pthread_t thread;
  /*! Enabled features informatio */
  struct ast_bridge_features features;
  /*! Array of channels that the bridge thread is currently handlin */
- struct ast_channel \*\*array;
+ struct ast_channel **array;
  /*! Number of channels in the above arra */
  size_t array_num;
  /*! Number of channels the array can handl */
  size_t array_size;
  /*! Call ID associated with the bridg */
- struct ast_callid \*callid;
+ struct ast_callid *callid;
  /*! Linked list of channels participating in the bridg */
  AST_LIST_HEAD_NOLOCK(, ast_bridge_channel) channels;
  /*! Linked list of channels removed from the bridge and waiting to be departed */
@@ -318,14 +318,14 @@ Create a new instance of `ast_bridge` with the requested capabilities.
  * Example usage:
  *
  * \code
- * struct ast_bridge \*bridge;
+ * struct ast_bridge *bridge;
  * bridge = ast_bridge_new(AST_BRIDGE_CAPABILITY_1TO1MIX, AST_BRIDGE_FLAG_DISSOLVE_HANGUP);
  * \endcode
  *
  * This creates a simple two party bridge that will be destroyed once one of
  * the channels hangs up.
  */
-struct ast_bridge \*ast_bridge_new(uint32_t capabilities, int flags);
+struct ast_bridge *ast_bridge_new(uint32_t capabilities, int flags);
 
 ```
 
@@ -343,7 +343,7 @@ Lock the bridge. While locked, the state of the bridge cannot be changed by exte
  * \return Nothing
  */
 #define ast_bridge_lock(bridge) _ast_bridge_lock(bridge, __FILE__, __PRETTY_FUNCTION__, __LINE__, #bridge)
-static inline void _ast_bridge_lock(struct ast_bridge \*bridge, const char \*file, const char \*function, int line, const char \*var)
+static inline void _ast_bridge_lock(struct ast_bridge *bridge, const char *file, const char *function, int line, const char *var)
 {
  __ao2_lock(bridge, AO2_LOCK_REQ_MUTEX, file, function, line, var);
 }
@@ -364,7 +364,7 @@ Unlock the bridge.
  * \return Nothing
  */
 #define ast_bridge_unlock(bridge) _ast_bridge_unlock(bridge, __FILE__, __PRETTY_FUNCTION__, __LINE__, #bridge)
-static inline void _ast_bridge_unlock(struct ast_bridge \*bridge, const char \*file, const char \*function, int line, const char \*var)
+static inline void _ast_bridge_unlock(struct ast_bridge *bridge, const char *file, const char *function, int line, const char *var)
 {
  __ao2_unlock(bridge, file, function, line, var);
 }
@@ -420,7 +420,7 @@ Explicitly destroy a bridge. Note that a self managing bridge will automatically
  *
  * This destroys a bridge that was previously created using ast_bridge_new.
  */
-int ast_bridge_destroy(struct ast_bridge \*bridge);
+int ast_bridge_destroy(struct ast_bridge *bridge);
 
 ```
 
@@ -468,11 +468,11 @@ It is up to the caller of the function to decide what happens next. In general, 
  * If channel specific features are enabled a pointer to the features structure
  * can be specified in the features parameter.
  */
-enum ast_bridge_channel_state ast_bridge_join(struct ast_bridge \*bridge,
- struct ast_channel \*chan,
- struct ast_channel \*swap,
- struct ast_bridge_features \*features,
- struct ast_bridge_tech_optimizations \*tech_args);
+enum ast_bridge_channel_state ast_bridge_join(struct ast_bridge *bridge,
+ struct ast_channel *chan,
+ struct ast_channel *swap,
+ struct ast_bridge_features *features,
+ struct ast_bridge_tech_optimizations *tech_args);
 
 ```
 
@@ -538,7 +538,7 @@ When the channel leaves the bridge the channel will:
  * Channels placed into a bridge by ast_bridge_join() are
  * removed by a third party using ast_bridge_remove().
  */
-int ast_bridge_impart(struct ast_bridge \*bridge, struct ast_channel \*chan, struct ast_channel \*swap, struct ast_bridge_features \*features, int independent);
+int ast_bridge_impart(struct ast_bridge *bridge, struct ast_channel *chan, struct ast_channel *swap, struct ast_bridge_features *features, int independent);
 
 ```
 
@@ -570,7 +570,7 @@ Remove a previously imparted `ast_channel` from the bridge.
  * \note This API call can only be used on channels that were added to the bridge
  * using the ast_bridge_impart API call with the independent flag FALSE.
  */
-int ast_bridge_depart(struct ast_bridge \*bridge, struct ast_channel \*chan);
+int ast_bridge_depart(struct ast_bridge *bridge, struct ast_channel *chan);
 
 ```
 
@@ -602,7 +602,7 @@ Remove any channel from the bridge.
  * \note This API call can be used on channels that were added to the bridge
  * using both ast_bridge_join and ast_bridge_impart.
  */
-int ast_bridge_remove(struct ast_bridge \*bridge, struct ast_channel \*chan);
+int ast_bridge_remove(struct ast_bridge *bridge, struct ast_channel *chan);
 
 ```
 
@@ -633,7 +633,7 @@ Merge two bridges together.
  * \note The second bridge specified is not destroyed when this operation is
  * completed.
  */
-int ast_bridge_merge(struct ast_bridge \*bridge0, struct ast_bridge \*bridge1);
+int ast_bridge_merge(struct ast_bridge *bridge0, struct ast_bridge *bridge1);
 
 ```
 
@@ -665,7 +665,7 @@ Suspend a channel from the bridge. Channels that are suspended from the bridge a
  * \note This API call can be used on channels that were added to the bridge
  * using both ast_bridge_join and ast_bridge_impart.
  */
-int ast_bridge_suspend(struct ast_bridge \*bridge, struct ast_channel \*chan);
+int ast_bridge_suspend(struct ast_bridge *bridge, struct ast_channel *chan);
 
 ```
 
@@ -696,7 +696,7 @@ Unsuspend a previously suspended channel, returning control of it back to the br
  * \note You must not mess with the channel once this function returns.
  * Doing so may result in bad things happening.
  */
-int ast_bridge_unsuspend(struct ast_bridge \*bridge, struct ast_channel \*chan);
+int ast_bridge_unsuspend(struct ast_bridge *bridge, struct ast_channel *chan);
 
 ```
 
@@ -729,7 +729,7 @@ Change the state of a bridged channel.
  * \note This API call is only meant to be used in feature hook callbacks to
  * request the channel exit the bridge.
  */
-void ast_bridge_change_state(struct ast_bridge_channel \*bridge_channel, enum ast_bridge_channel_state new_state);
+void ast_bridge_change_state(struct ast_bridge_channel *bridge_channel, enum ast_bridge_channel_state new_state);
 
 ```
 
@@ -749,7 +749,7 @@ If a bridging technology supports the multimix capability, set the mixing sampli
  * what ever sample rate it chooses.
  *
  */
-void ast_bridge_set_internal_sample_rate(struct ast_bridge \*bridge, unsigned int sample_rate);
+void ast_bridge_set_internal_sample_rate(struct ast_bridge *bridge, unsigned int sample_rate);
 
 ```
 
@@ -767,7 +767,7 @@ If a bridging technology supports the multimix capability, set the mixing interv
  * \param mixing_interval the sample rate to change to. If 0 is set
  * the bridge tech is free to choose any mixing interval it uses by default.
  */
-void ast_bridge_set_mixing_interval(struct ast_bridge \*bridge, unsigned int mixing_interval);
+void ast_bridge_set_mixing_interval(struct ast_bridge *bridge, unsigned int mixing_interval);
 
 ```
 
@@ -780,7 +780,7 @@ If a bridging technology supports video, set the single video source to feed to 
 /*!
  * \brief Set a bridge to feed a single video source to all participants.
  */
-void ast_bridge_set_single_src_video_mode(struct ast_bridge \*bridge, struct ast_channel \*video_src_chan);
+void ast_bridge_set_single_src_video_mode(struct ast_bridge *bridge, struct ast_channel *video_src_chan);
 
 ```
 
@@ -794,7 +794,7 @@ If a bridging technology supports video, set the video mode to use the current t
  * \brief Set the bridge to pick the strongest talker supporting
  * video as the single source video feed
  */
-void ast_bridge_set_talker_src_video_mode(struct ast_bridge \*bridge);
+void ast_bridge_set_talker_src_video_mode(struct ast_bridge *bridge);
 
 ```
 
@@ -807,7 +807,7 @@ Inform a video capable bridging technology about the talk energy and frame infor
 /*!
  * \brief Update information about talker energy for talker src video mode.
  */
-void ast_bridge_update_talker_src_video_mode(struct ast_bridge \*bridge, struct ast_channel \*chan, int talker_energy, int is_keyfame);
+void ast_bridge_update_talker_src_video_mode(struct ast_bridge *bridge, struct ast_channel *chan, int talker_energy, int is_keyfame);
 
 ```
 
@@ -820,7 +820,7 @@ Get the number of video sources in the bridge.
 /*!
  * \brief Returns the number of video sources currently active in the bridge
  */
-int ast_bridge_number_video_src(struct ast_bridge \*bridge);
+int ast_bridge_number_video_src(struct ast_bridge *bridge);
 
 ```
 
@@ -838,7 +838,7 @@ Return whether or not a channel is a video source.
  * returned represents the priority this video stream has
  * on the bridge where 1 is the highest priority.
  */
-int ast_bridge_is_video_src(struct ast_bridge \*bridge, struct ast_channel \*chan);
+int ast_bridge_is_video_src(struct ast_bridge *bridge, struct ast_channel *chan);
 
 ```
 
@@ -851,7 +851,7 @@ Remove a channel from being the video source.
 /*!
  * \brief remove a channel as a source of video for the bridge.
  */
-void ast_bridge_remove_video_src(struct ast_bridge \*bridge, struct ast_channel \*chan);
+void ast_bridge_remove_video_src(struct ast_bridge *bridge, struct ast_channel *chan);
 
 ```
 
@@ -893,40 +893,40 @@ The interface that defines a bridging technology.
  */
 struct ast_bridge_technology {
  /*! Unique name to this bridge technolog */
- const char \*name;
+ const char *name;
  /*! The capabilities that this bridge technology is capable of. This has nothing to do with
  * format capabilities */
  uint32_t capabilities;
  /*! Preference level that should be used when determining whether to use this bridge technology or no */
  enum ast_bridge_preference preference;
  /*! Callback for when a bridge is being create */
- int (\*create)(struct ast_bridge \*bridge);
+ int (*create)(struct ast_bridge *bridge);
  /*! Callback for when a bridge is being destroye */
- int (\*destroy)(struct ast_bridge \*bridge);
+ int (*destroy)(struct ast_bridge *bridge);
  /*! Callback for when a channel is being added to a bridg */
- int (\*join)(struct ast_bridge \*bridge, struct ast_bridge_channel \*bridge_channel);
+ int (*join)(struct ast_bridge *bridge, struct ast_bridge_channel *bridge_channel);
  /*! Callback for when a channel is leaving a bridg */
- int (\*leave)(struct ast_bridge \*bridge, struct ast_bridge_channel \*bridge_channel);
+ int (*leave)(struct ast_bridge *bridge, struct ast_bridge_channel *bridge_channel);
  /*! Callback for when a channel is suspended from the bridg */
- void (\*suspend)(struct ast_bridge \*bridge, struct ast_bridge_channel \*bridge_channel);
+ void (*suspend)(struct ast_bridge *bridge, struct ast_bridge_channel *bridge_channel);
  /*! Callback for when a channel is unsuspended from the bridg */
- void (\*unsuspend)(struct ast_bridge \*bridge, struct ast_bridge_channel \*bridge_channel);
+ void (*unsuspend)(struct ast_bridge *bridge, struct ast_bridge_channel *bridge_channel);
  /*! Callback to see if a channel is compatible with the bridging technolog */
- int (\*compatible)(struct ast_bridge_channel \*bridge_channel);
+ int (*compatible)(struct ast_bridge_channel *bridge_channel);
  /*! Callback for writing a frame into the bridging technolog */
- enum ast_bridge_write_result (\*write)(struct ast_bridge \*bridge, struct ast_bridge_channel \*bridged_channel, struct ast_frame \*frame);
+ enum ast_bridge_write_result (*write)(struct ast_bridge *bridge, struct ast_bridge_channel *bridged_channel, struct ast_frame *frame);
  /*! Callback for when a file descriptor trip */
- int (\*fd)(struct ast_bridge \*bridge, struct ast_bridge_channel \*bridge_channel, int fd);
+ int (*fd)(struct ast_bridge *bridge, struct ast_bridge_channel *bridge_channel, int fd);
  /*! Callback for replacement thread functio */
- int (\*thread)(struct ast_bridge \*bridge);
+ int (*thread)(struct ast_bridge *bridge);
  /*! Callback for poking a bridge threa */
- int (\*poke)(struct ast_bridge \*bridge, struct ast_bridge_channel \*bridge_channel);
+ int (*poke)(struct ast_bridge *bridge, struct ast_bridge_channel *bridge_channel);
  /*! Formats that the bridge technology support */
- struct ast_format_cap \*format_capabilities;
+ struct ast_format_cap *format_capabilities;
  /*! Bit to indicate whether the bridge technology is currently suspended or no */
  unsigned int suspended:1;
  /*! Module this bridge technology belongs to. Is used for reference counting when creating/destroying a bridge */
- struct ast_module \*mod;
+ struct ast_module *mod;
  /*! Linked list informatio */
  AST_RWLIST_ENTRY(ast_bridge_technology) entry;
 };
@@ -961,7 +961,7 @@ Register a technology with the Bridging Framework.
  * simple_bridge_tech with the bridging core and makes it available for
  * use when creating bridges.
  */
-int __ast_bridge_technology_register(struct ast_bridge_technology \*technology, struct ast_module \*mod);
+int __ast_bridge_technology_register(struct ast_bridge_technology *technology, struct ast_module *mod);
 
 /*! \brief See \ref __ast_bridge_technology_register( */
 #define ast_bridge_technology_register(technology) __ast_bridge_technology_register(technology, ast_module_info->self)
@@ -992,7 +992,7 @@ Unregister a technology with the Bridging Framework.
  * simple_bridge_tech with the bridging core. It will no longer be
  * considered when creating a new bridge.
  */
-int ast_bridge_technology_unregister(struct ast_bridge_technology \*technology);
+int ast_bridge_technology_unregister(struct ast_bridge_technology *technology);
 
 ```
 
@@ -1021,7 +1021,7 @@ Notify the Bridging Framework that a channel has a frame waiting.
  *
  * \note This should only be used by bridging technologies.
  */
-void ast_bridge_handle_trip(struct ast_bridge \*bridge, struct ast_bridge_channel \*bridge_channel, struct ast_channel \*chan, int outfd);
+void ast_bridge_handle_trip(struct ast_bridge *bridge, struct ast_bridge_channel *bridge_channel, struct ast_channel *chan, int outfd);
 
 ```
 
@@ -1044,7 +1044,7 @@ Notify the Bridging Framework that a channel has started talking.
  * \param started_talking set to 1 when this indicates the channel has started talking set to 0
  * when this indicates the channel has stopped talking.
  */
-void ast_bridge_notify_talking(struct ast_bridge_channel \*bridge_channel, int started_talking);
+void ast_bridge_notify_talking(struct ast_bridge_channel *bridge_channel, int started_talking);
 
 ```
 
@@ -1069,7 +1069,7 @@ Suspend a bridging technology from consideration by the Bridging Framework.
  * when creating a new bridge. Existing bridges using the bridge technology
  * are not affected.
  */
-void ast_bridge_technology_suspend(struct ast_bridge_technology \*technology);
+void ast_bridge_technology_suspend(struct ast_bridge_technology *technology);
 
 ```
 
@@ -1093,6 +1093,6 @@ Unsuspend a bridging technology from consideration by the Bridging Framework.
  * This makes the bridge technology simple_bridge_tech considered when
  * creating a new bridge again.
  */
-void ast_bridge_technology_unsuspend(struct ast_bridge_technology \*technology);
+void ast_bridge_technology_unsuspend(struct ast_bridge_technology *technology);
 
 ```

--- a/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-Bridging-Project/index.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/Asterisk-12-Bridging-Project/index.md
@@ -493,19 +493,19 @@ Park, Queue, ConfBridge could be derivative classes of the abstract bridge class
 ```
 
 class ast_bridge {
- join(struct ast_channel \*chan);
- depart(struct ast_channel \*chan);
- remove(struct ast_channel \*chan);
- move_pull(class ast_bridge_channel \*chan);
+ join(struct ast_channel *chan);
+ depart(struct ast_channel *chan);
+ remove(struct ast_channel *chan);
+ move_pull(class ast_bridge_channel *chan);
  Pull a channel out of this bridge to be pushed into another bridge.
- move_push(class ast_bridge_channel \*chan, class ast_bridge_channel \*swap);
+ move_push(class ast_bridge_channel *chan, class ast_bridge_channel *swap);
  Push a channel into this bridge that was pulled from another bridge.
- masquerade_pull(class ast_bridge_channel \*chan);
+ masquerade_pull(class ast_bridge_channel *chan);
  A masquerade is figuratively pulling this channel out of the bridge
  to be pushed back in as a new channel.
  This is done for the clone and original channels because a masquerade
  swaps the guts of the two channels.
- masquerade_push(class ast_bridge_channel \*chan);
+ masquerade_push(class ast_bridge_channel *chan);
  Push the channel back into the bridge as a new channel.
  poke();
  new();
@@ -519,7 +519,7 @@ class ast_bridge {
  of a swapped channel when it is pushed or joined.
 };
 class ast_bridge_channel {
- class ast_bridge \*bridge;
+ class ast_bridge *bridge;
  suspend();
  Mark channel as suspended and poke the bridge to recognize it.
  unsuspend();

--- a/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/How-to-extend-SIP-functionality-in-Asterisk/Writing-a-SIP-Session-Supplement.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/How-to-extend-SIP-functionality-in-Asterisk/Writing-a-SIP-Session-Supplement.md
@@ -43,12 +43,12 @@ Let's consider what we need to do for this feature to work. All we have to do is
 #include "asterisk/res_pjsip_session.h"
 #include "asterisk/module.h"
 
-/*\*\* MODULEINFO
+/*** MODULEINFO
  <depend>pjproject</depend>
  <depend>res_pjsip</depend>
  <depend>res_pjsip_session</depend>
- *\* */
-static void auto_answer_outgoing_request(struct ast_sip_session \*session, pjsip_tx_data \*tdata)
+ ** */
+static void auto_answer_outgoing_request(struct ast_sip_session *session, pjsip_tx_data *tdata)
 {
  /* STU */
 }
@@ -95,11 +95,11 @@ c#include "asterisk.h"
 #include "asterisk/res_pjsip_session.h"
 #include "asterisk/module.h"
 
-/*\*\* MODULEINFO
+/*** MODULEINFO
  <depend>pjproject</depend>
  <depend>res_pjsip</depend>
  <depend>res_pjsip_session</depend>
- *\* */
+ ** */
 
 ```
 
@@ -141,7 +141,7 @@ We will not go into a lot of detail about the module-specific code here since it
 Now let's have a look at the important part of the code:
 
 ```
-cstatic void auto_answer_outgoing_request(struct ast_sip_session \*session, pjsip_tx_data \*tdata)
+cstatic void auto_answer_outgoing_request(struct ast_sip_session *session, pjsip_tx_data *tdata)
 {
  /* STU */
 }
@@ -168,7 +168,7 @@ Filling in the supplement callback
 Let's take a look at where we are currently with our callback:
 
 ```
-cstatic void auto_answer_outgoing_request(struct ast_sip_session \*session, pjsip_tx_data \*tdata)
+cstatic void auto_answer_outgoing_request(struct ast_sip_session *session, pjsip_tx_data *tdata)
 {
  /* STU */
 }
@@ -187,13 +187,13 @@ The top one requires that the UAS supports the "answermode" option. A UAS that d
 So let's add these headers:
 
 ```
-cstatic void auto_answer_outgoing_request(struct ast_sip_session \*session, pjsip_tx_data \*tdata)
+cstatic void auto_answer_outgoing_request(struct ast_sip_session *session, pjsip_tx_data *tdata)
 {
  static const pj_str_t answer_mode_name = { "Answer-Mode", 11 };
  static const pj_str_t answer_mode_value = { "auto", 4 };
  static const pj_str_t require_value = { "answermode", 10 };
- pjsip_generic_string_hdr \*answer_mode;
- pjsip_require_hdr \*require;
+ pjsip_generic_string_hdr *answer_mode;
+ pjsip_require_hdr *require;
 
  /* Let's add the require header. There could already be a require header present in the
  * request. If so, then we just need to add "answermode" to the list of requirements. Otherwise,
@@ -202,7 +202,7 @@ cstatic void auto_answer_outgoing_request(struct ast_sip_session \*session, pjsi
  require = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_REQUIRE, NULL);
  if (!require) {
  require = pjsip_require_hdr_create(tdata->pool);
- pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr \*) require);
+ pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) require);
  }
  pj_strdup(tdata->pool, &require->values[require->count++], &require_value);
 
@@ -210,7 +210,7 @@ cstatic void auto_answer_outgoing_request(struct ast_sip_session \*session, pjsi
  * header to the message before we get it.
  */
  answer_mode = pjsip_generic_string_hdr_create(tdata->pool, &answer_mode_name, &answer_mode_value);
- pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr \*) answer_mode);
+ pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) answer_mode);
 }
 
 ```
@@ -223,8 +223,8 @@ Now we have some content! Let's go into it in more detail, starting from the top
 c static const pj_str_t answer_mode_name = { "Answer-Mode", 11 };
  static const pj_str_t answer_mode_value = { "auto", 4 };
  static const pj_str_t require_value = { "answermode", 10 };
- pjsip_generic_string_hdr \*answer_mode;
- pjsip_require_hdr \*require;
+ pjsip_generic_string_hdr *answer_mode;
+ pjsip_require_hdr *require;
 
 ```
 
@@ -238,7 +238,7 @@ Next, let's have a look at what we are doing with the Require header:
 c require = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_REQUIRE, NULL);
  if (!require) {
  require = pjsip_require_hdr_create(tdata->pool);
- pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr \*) require);
+ pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) require);
  }
  pj_cstr(&require->values[require->count++], &require_value);
 
@@ -252,7 +252,7 @@ Next, let's have a look at what we are doing with the Auto-Answer header:
 
 ```
 c answer_mode = pjsip_generic_string_hdr_create(tdata->pool, &answer_mode_name, &answer_mode_value);
- pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr \*) answer_mode);
+ pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) answer_mode);
 
 ```
 
@@ -267,7 +267,7 @@ At this point, we have a simple session supplement written, but we don't actuall
 
 ```
 c ...
- pjsip_require_hdr \*require;
+ pjsip_require_hdr *require;
  int add_auto_answer;
 
  ast_channel_lock(session->channel);
@@ -321,18 +321,18 @@ At this point, we are finished. So let's put it all together and see what we hav
 #include "asterisk/module.h"
 #include "asterisk/pbx.h"
 
-/*\*\* MODULEINFO
+/*** MODULEINFO
  <depend>pjproject</depend>
  <depend>res_pjsip</depend>
  <depend>res_pjsip_session</depend>
- *\* */
-static void auto_answer_outgoing_request(struct ast_sip_session \*session, pjsip_tx_data \*tdata)
+ ** */
+static void auto_answer_outgoing_request(struct ast_sip_session *session, pjsip_tx_data *tdata)
 {
  static const pj_str_t answer_mode_name = { "Answer-Mode", 11 };
  static const pj_str_t answer_mode_value = { "auto", 4 };
  static const pj_str_t require_value = { "answermode", 10 };
- pjsip_generic_string_hdr \*answer_mode;
- pjsip_require_hdr \*require;
+ pjsip_generic_string_hdr *answer_mode;
+ pjsip_require_hdr *require;
  int add_auto_answer;
 
  if (session->inv_session->state >= PJSIP_INV_STATE_CONFIRMED) {
@@ -354,7 +354,7 @@ static void auto_answer_outgoing_request(struct ast_sip_session \*session, pjsip
  require = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_REQUIRE, NULL);
  if (!require) {
  require = pjsip_require_hdr_create(tdata->pool);
- pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr \*) require);
+ pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) require);
  }
  pj_strdup(tdata->pool, &require->values[require->count++], &require_value);
 
@@ -362,7 +362,7 @@ static void auto_answer_outgoing_request(struct ast_sip_session \*session, pjsip
  * header to the message before we get it.
  */
  answer_mode = pjsip_generic_string_hdr_create(tdata->pool, &answer_mode_name, &answer_mode_value);
- pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr \*) answer_mode);
+ pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *) answer_mode);
 }
 
 static struct ast_sip_session_supplement auto_answer_supplement = {

--- a/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/New-SIP-Channel-Driver-Architecture/Event-Subscription-and-Publication-Design.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/New-SIP-Channel-Driver-Architecture/Event-Subscription-and-Publication-Design.md
@@ -57,8 +57,8 @@ enum ast_sip_subscription_role {
  * \param endpoint The endpoint involved in this subscription
  * \param rdata If acting as a notifier, the SUBSCRIBE request that triggered subscription creation
  */
-struct ast_sip_subscription \*ast_sip_create_subscription(const struct ast_sip_subscription_handler \*handler,
- enum ast_sip_subscription_role role, struct ast_sip_endpoint \*endpoint, pjsip_rx_data \*rdata);
+struct ast_sip_subscription *ast_sip_create_subscription(const struct ast_sip_subscription_handler *handler,
+ enum ast_sip_subscription_role role, struct ast_sip_endpoint *endpoint, pjsip_rx_data *rdata);
 
 /*!
  * \brief Get the endpoint that is associated with this subscription
@@ -66,7 +66,7 @@ struct ast_sip_subscription \*ast_sip_create_subscription(const struct ast_sip_s
  * \retval NULL Could not get endpoint
  * \retval non-NULL The endpoint
  */
-struct ast_sip_endpoint \*ast_sip_subscription_get_endpoint(struct ast_sip_subscription \*sub);
+struct ast_sip_endpoint *ast_sip_subscription_get_endpoint(struct ast_sip_subscription *sub);
 
 /*!
  * \brief Get the serializer for the subscription
@@ -78,7 +78,7 @@ struct ast_sip_endpoint \*ast_sip_subscription_get_endpoint(struct ast_sip_subsc
  * \retval NULL Failure
  * \retval non-NULL The subscription's serializer
  */
-struct ast_sip_serializer \*ast_sip_subscription_get_serializer(struct ast_sip_subscription \*sub);
+struct ast_sip_serializer *ast_sip_subscription_get_serializer(struct ast_sip_subscription *sub);
 
 /*!
  * \brief Get the underlying PJSIP evsub structure
@@ -93,7 +93,7 @@ struct ast_sip_serializer \*ast_sip_subscription_get_serializer(struct ast_sip_s
  * \retval NULL Failure
  * \retval non-NULL The underlying pjsip_evsub
  */
-pjsip_evsub \*ast_sip_subscription_get_evsub(struct ast_sip_subscription \*sub);
+pjsip_evsub *ast_sip_subscription_get_evsub(struct ast_sip_subscription *sub);
 
 /*!
  * \brief Send a request created via a PJSIP evsub method
@@ -106,7 +106,7 @@ pjsip_evsub \*ast_sip_subscription_get_evsub(struct ast_sip_subscription \*sub);
  * \retval 0 Success
  * \retval non-zero Failure
  */
-int ast_sip_subscription_send_request(struct ast_sip_subscription \*sub, pjsip_tx_data \*tdata);
+int ast_sip_subscription_send_request(struct ast_sip_subscription *sub, pjsip_tx_data *tdata);
 
 /*!
  * \brief Alternative for ast_datastore_alloc()
@@ -124,7 +124,7 @@ int ast_sip_subscription_send_request(struct ast_sip_subscription \*sub, pjsip_t
  * \retval NULL Failed to allocate datastore
  * \retval non-NULL Newly allocated datastore
  */
-struct ast_datastore \*ast_sip_subscription_alloc_datastore(const struct ast_datastore_info \*info, const char \*uid);
+struct ast_datastore *ast_sip_subscription_alloc_datastore(const struct ast_datastore_info *info, const char *uid);
 
 /*!
  * \brief Add a datastore to a SIP subscription
@@ -137,7 +137,7 @@ struct ast_datastore \*ast_sip_subscription_alloc_datastore(const struct ast_dat
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_subscription_add_datastore(struct ast_sip_subscription \*subscription, struct ast_datastore \*datastore);
+int ast_sip_subscription_add_datastore(struct ast_sip_subscription *subscription, struct ast_datastore *datastore);
 
 /*!
  * \brief Retrieve a subscription datastore
@@ -150,7 +150,7 @@ int ast_sip_subscription_add_datastore(struct ast_sip_subscription \*subscriptio
  * \retval NULL Failed to find the specified datastore
  * \retval non-NULL The specified datastore
  */
-struct ast_datastore \*ast_sip_subscription_get_datastore(struct ast_sip_subscription \*subscription, const char \*name);
+struct ast_datastore *ast_sip_subscription_get_datastore(struct ast_sip_subscription *subscription, const char *name);
 
 /*!
  * \brief Remove a subscription datastore from the subscription
@@ -161,7 +161,7 @@ struct ast_datastore \*ast_sip_subscription_get_datastore(struct ast_sip_subscri
  * \param subscription The subscription to remove the datastore from
  * \param name The name of the datastore to remove
  */
-void ast_sip_subscription_remove_datastore(struct ast_sip_subscription \*subscription, const char \*name);
+void ast_sip_subscription_remove_datastore(struct ast_sip_subscription *subscription, const char *name);
 
 ```
 
@@ -188,18 +188,18 @@ struct ast_sip_subscription_response_data {
  /*! Status code of the respons */
  int status_code;
  /*! Optional status tex */
- const char \*status_text;
+ const char *status_text;
  /*! Optional additional headers to add to the respons */
- struct ast_variable \*headers;
+ struct ast_variable *headers;
  /*! Optional body to add to the respons */
- struct ast_sip_body \*body;
+ struct ast_sip_body *body;
 };
 
 struct ast_sip_subscription_handler {
  /*! The name of the event this handler deals wit */
- const char \*event_name;
+ const char *event_name;
  /*! The types of body this handler accept */
- const char \*accept[];
+ const char *accept[];
 
  /*!
  * \brief Called when a subscription is to be destroyed
@@ -210,7 +210,7 @@ struct ast_sip_subscription_handler {
  * during this callback. This callback is useful for performing any
  * necessary cleanup
  */
- void (\*subscription_shutdown)(struct ast_sip_subscription \*subscription);
+ void (*subscription_shutdown)(struct ast_sip_subscription *subscription);
 
  /*!
  * \brief Called when a SUBSCRIBE arrives in order to create a new subscription
@@ -229,8 +229,8 @@ struct ast_sip_subscription_handler {
  * \retval NULL The SUBSCRIBE has not been accepted
  * \retval non-NULL The newly-created subscription
  */
- struct ast_sip_subscription \*(\*new_subscribe)(struct ast_sip_endpoint \*endpoint,
- pjsip_rx_data \*rdata);
+ struct ast_sip_subscription *(*new_subscribe)(struct ast_sip_endpoint *endpoint,
+ pjsip_rx_data *rdata);
 
  /*!
  * \brief Called when an endpoint renews a subscription.
@@ -245,8 +245,8 @@ struct ast_sip_subscription_handler {
  * \retval NULL Allow the default 200 OK response to be sent
  * \retval non-NULL Send a response with the specified data present
  */
- struct ast_sip_subscription_response_data \*(\*resubscribe)(struct ast_sip_subscription \*sub,
- pjsip_rx_data \*rdata);
+ struct ast_sip_subscription_response_data *(*resubscribe)(struct ast_sip_subscription *sub,
+ pjsip_rx_data *rdata);
 
  /*!
  * \brief Called when a subscription times out.
@@ -258,7 +258,7 @@ struct ast_sip_subscription_handler {
  *
  * \param sub The subscription that has timed out
  */
- void (\*subscription_timeout)(struct ast_sip_subscription \*sub);
+ void (*subscription_timeout)(struct ast_sip_subscription *sub);
 
  /*!
  * \brief Called when a subscription is terminated via a SUBSCRIBE request
@@ -272,7 +272,7 @@ struct ast_sip_subscription_handler {
  * \param sub The subscription being terminated
  * \param rdata The SUBSCRIBE request that terminated the subscription
  */
- void (\*subscription_terminated)(struct ast_sip_subscription \*sub, pjsip_rx_data \*rdata);
+ void (*subscription_terminated)(struct ast_sip_subscription *sub, pjsip_rx_data *rdata);
 
  /*!
  * \brief Called when a subscription handler's outbound NOTIFY receives a response
@@ -282,7 +282,7 @@ struct ast_sip_subscription_handler {
  * \param sub The subscription
  * \param rdata The NOTIFY response
  */
- void (\*notify_response)(struct ast_sip_subscription \*sub, pjsip_rx_data \*rdata);
+ void (*notify_response)(struct ast_sip_subscription *sub, pjsip_rx_data *rdata);
 
  /*!
  * \brief Called when a subscription handler receives an inbound NOTIFY
@@ -299,8 +299,8 @@ struct ast_sip_subscription_handler {
  * \retval NULL Have the framework send the default 200 OK response
  * \retval non-NULL Send a response with the specified data
  */
- struct ast_sip_subscription_response_data \*(\*notify_request)(struct ast_sip_subscription \*sub,
- pjsip_rx_data \*rdata);
+ struct ast_sip_subscription_response_data *(*notify_request)(struct ast_sip_subscription *sub,
+ pjsip_rx_data *rdata);
 
  /*!
  * \brief Called when it is time for a subscriber to resubscribe
@@ -314,7 +314,7 @@ struct ast_sip_subscription_handler {
  * \retval 0 Success
  * \retval non-zero Failure
  */
- int (\*refresh_subscription)(struct ast_sip_subscription \*sub);
+ int (*refresh_subscription)(struct ast_sip_subscription *sub);
 };
 
 /*!
@@ -323,12 +323,12 @@ struct ast_sip_subscription_handler {
  * \retval 0 Handler was registered successfully
  * \retval non-zero Handler was not registered successfully
  */
-int ast_sip_register_subscription_handler(const struct ast_sip_subscription_handler \*handler);
+int ast_sip_register_subscription_handler(const struct ast_sip_subscription_handler *handler);
 
 /*!
  * \brief Unregister a subscription handler
  */
-void ast_sip_unregister_subscription_handler(const struct ast_sip_subscription_handler \*handler);
+void ast_sip_unregister_subscription_handler(const struct ast_sip_subscription_handler *handler);
 
 ```
 
@@ -363,7 +363,7 @@ struct ast_sip_publication_handler {
  * \retval NULL PUBLISH was not accepted
  * \retval non-NULL New publication
  */
- struct ast_sip_publication \*(\*new_publication)(struct ast_sip_endpoint \*endpoint, pjsip_rx_data \*rdata);
+ struct ast_sip_publication *(*new_publication)(struct ast_sip_endpoint *endpoint, pjsip_rx_data *rdata);
  /*!
  * \brief Called when a PUBLISH for an existing publication arrives.
  *
@@ -376,11 +376,11 @@ struct ast_sip_publication_handler {
  * \retval 0 Publication was accepted
  * \retval non-zero Publication was denied
  */
- int (\*publish_refresh)(struct ast_sip_publication \*pub, pjsip_rx_data \*rdata);
+ int (*publish_refresh)(struct ast_sip_publication *pub, pjsip_rx_data *rdata);
  /*!
  * \brief Called when a publication has reached its expiration.
  */
- void (\*publish_expire)(struct ast_sip_publication \*pub);
+ void (*publish_expire)(struct ast_sip_publication *pub);
  /*!
  * \brief Called when a PUBLISH arrives to terminate a publication.
  *
@@ -389,7 +389,7 @@ struct ast_sip_publication_handler {
  * \param pub The publication that is terminating
  * \param rdata The PUBLISH request terminating the publication
  */
- void (\*publish_termination)(struct ast_sip_publication \*pub, pjsip_rx_data \*rdata);
+ void (*publish_termination)(struct ast_sip_publication *pub, pjsip_rx_data *rdata);
 };
 
 /*!
@@ -402,7 +402,7 @@ struct ast_sip_publication_handler {
  * \retval NULL Failed to create a publication
  * \retval non-NULL The newly-created publication
  */
-struct ast_sip_publication \*ast_sip_create_publication(struct ast_sip_endpoint \*endpoint, pjsip_rx_data \*rdata);
+struct ast_sip_publication *ast_sip_create_publication(struct ast_sip_endpoint *endpoint, pjsip_rx_data *rdata);
 
 /*!
  * \brief Given a publication, get the associated endpoint
@@ -411,7 +411,7 @@ struct ast_sip_publication \*ast_sip_create_publication(struct ast_sip_endpoint 
  * \retval NULL Failure
  * \retval non-NULL The associated endpoint
  */
-struct ast_sip_endpoint \*ast_sip_publication_get_endpoint(struct ast_sip_publication \*pub);
+struct ast_sip_endpoint *ast_sip_publication_get_endpoint(struct ast_sip_publication *pub);
 
 /*!
  * \brief Create a response to an inbound PUBLISH
@@ -423,7 +423,7 @@ struct ast_sip_endpoint \*ast_sip_publication_get_endpoint(struct ast_sip_public
  * \param rdata The request to which the response is being made
  * \param[out] tdat The created response
  */
-int ast_sip_publication_create_response(struct ast_sip_publication \*pub, int status_code, pjsip_rx_data \*rdata);
+int ast_sip_publication_create_response(struct ast_sip_publication *pub, int status_code, pjsip_rx_data *rdata);
 
 /*!
  * \brief Alternative for ast_datastore_alloc()
@@ -441,7 +441,7 @@ int ast_sip_publication_create_response(struct ast_sip_publication \*pub, int st
  * \retval NULL Failed to allocate datastore
  * \retval non-NULL Newly allocated datastore
  */
-struct ast_datastore \*ast_sip_subscription_alloc_datastore(const struct ast_datastore_info \*info, const char \*uid);
+struct ast_datastore *ast_sip_subscription_alloc_datastore(const struct ast_datastore_info *info, const char *uid);
 
 /*!
  * \brief Add a datastore to a SIP subscription
@@ -454,7 +454,7 @@ struct ast_datastore \*ast_sip_subscription_alloc_datastore(const struct ast_dat
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_subscription_add_datastore(struct ast_sip_subscription \*subscription, struct ast_datastore \*datastore);
+int ast_sip_subscription_add_datastore(struct ast_sip_subscription *subscription, struct ast_datastore *datastore);
 
 /*!
  * \brief Retrieve a subscription datastore
@@ -467,7 +467,7 @@ int ast_sip_subscription_add_datastore(struct ast_sip_subscription \*subscriptio
  * \retval NULL Failed to find the specified datastore
  * \retval non-NULL The specified datastore
  */
-struct ast_datastore \*ast_sip_subscription_get_datastore(struct ast_sip_subscription \*subscription, const char \*name);
+struct ast_datastore *ast_sip_subscription_get_datastore(struct ast_sip_subscription *subscription, const char *name);
 
 /*!
  * \brief Remove a subscription datastore from the subscription
@@ -478,6 +478,6 @@ struct ast_datastore \*ast_sip_subscription_get_datastore(struct ast_sip_subscri
  * \param subscription The subscription to remove the datastore from
  * \param name The name of the datastore to remove
  */
-void ast_sip_subscription_remove_datastore(struct ast_sip_subscription \*subscription, const char \*name);
+void ast_sip_subscription_remove_datastore(struct ast_sip_subscription *subscription, const char *name);
 
 ```

--- a/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/New-SIP-Channel-Driver-Architecture/res_sip-design/index.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/New-SIP-Channel-Driver-Architecture/res_sip-design/index.md
@@ -50,7 +50,7 @@ struct ast_sip_digest_challenge_data {
  /*!
  * The realm to which the user is authenticating. An authenticator MUST fill this in.
  */
- const char \*realm;
+ const char *realm;
  /*!
  * Indicates whether the username and password are in plaintext or encoded as MD5.
  * If this is non-zero, then the data is an MD5 sum. Otherwise, the username and password are plaintext.
@@ -69,13 +69,13 @@ struct ast_sip_digest_challenge_data {
  * Structure containing the username and password to encode in a digest authentication challenge.
  */
  struct {
- const char \*username;
- const char \*password;
+ const char *username;
+ const char *password;
  } plain;
  /*!
  * An MD5-encoded string that incorporates the username and password.
  */
- const char \*md5;
+ const char *md5;
  } auth;
  /*!
  * Domain for which the authentication challenge is being sent. This corresponds to the "domain=" portion of
@@ -83,17 +83,17 @@ struct ast_sip_digest_challenge_data {
  *
  * Authenticators do not have to fill in this field since it is an optional part of a digest.
  */
- const char \*domain;
+ const char *domain;
  /*!
  * Opaque string for digest challenge. This corresponds to the "opaque=" portion of a digest authentication.
  * Authenticators do not have to fill in this field. If an authenticator does not fill it in, Asterisk will provide one.
  */
- const char \*opaque;
+ const char *opaque;
  /*!
  * Nonce string for digest challenge. This corresponds to the "nonce=" portion of a digest authentication.
  * Authenticators do not have to fill in this field. If an authenticator does not fill it in, Asterisk will provide one.
  */
- const char \*nonce;
+ const char *nonce;
 };
 
 /*!
@@ -108,17 +108,17 @@ struct ast_sip_authenticator {
  * \brief Check if a request requires authentication
  * See ast_sip_requires_authentication for more details
  */
- int (\*requires_authentication)(struct ast_sip_endpoint \*endpoint, struct pjsip_rx_data \*rdata);
+ int (*requires_authentication)(struct ast_sip_endpoint *endpoint, struct pjsip_rx_data *rdata);
  /*!
  * \brief Attempt to authenticate the incoming request
  * See ast_sip_authenticate_request for more details
  */
- int (\*authenticate_request)(struct ast_sip_endpoint \*endpoint, struct pjsip_rx_data \*rdata);
+ int (*authenticate_request)(struct ast_sip_endpoint *endpoint, struct pjsip_rx_data *rdata);
  /*!
  * \brief Get digest authentication details
  * See ast_sip_get_authentication_credentials for more details
  */
- int (\*get_authentication_credentials)(struct ast_sip_endpoint \*endpoint, struct sip_digest_challenge_data \*challenge);
+ int (*get_authentication_credentials)(struct ast_sip_endpoint *endpoint, struct sip_digest_challenge_data *challenge);
 };
 
 /*!
@@ -129,7 +129,7 @@ struct ast_sip_endpoint_identifier {
  * \brief Callback used to identify the source of a message.
  * See ast_sip_identify_endpoint for more details
  */
- struct ast_sip_endpoint \*(\*identify_endpoint)(struct pjsip_rx_data \*data);
+ struct ast_sip_endpoint *(*identify_endpoint)(struct pjsip_rx_data *data);
 };
 
 ```
@@ -152,7 +152,7 @@ c
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_register_service(pjsip_module \*module);
+int ast_sip_register_service(pjsip_module *module);
 
 /*!
  * This is the opposite of ast_sip_register_service(). Unregistering a
@@ -161,7 +161,7 @@ int ast_sip_register_service(pjsip_module \*module);
  *
  * \param module The PJSIP module to unregister
  */
-void ast_sip_unregister_service(pjsip_module \*module);
+void ast_sip_unregister_service(pjsip_module *module);
 
 /*!
  * \brief Register a SIP authenticator
@@ -178,7 +178,7 @@ void ast_sip_unregister_service(pjsip_module \*module);
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_register_authenticator(struct ast_sip_authenticator \*auth);
+int ast_sip_register_authenticator(struct ast_sip_authenticator *auth);
 
 /*!
  * \brief Unregister a SIP authenticator
@@ -188,7 +188,7 @@ int ast_sip_register_authenticator(struct ast_sip_authenticator \*auth);
  *
  * \param auth The authenticator to unregister
  */
-void ast_sip_unregister_authenticator(struct ast_sip_authenticator \*auth);
+void ast_sip_unregister_authenticator(struct ast_sip_authenticator *auth);
 
 /*!
  * \brief Register a SIP endpoint identifier
@@ -211,7 +211,7 @@ void ast_sip_unregister_authenticator(struct ast_sip_authenticator \*auth);
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_register_endpoint_identifier(struct ast_sip_endpoint_identifier \*identifier);
+int ast_sip_register_endpoint_identifier(struct ast_sip_endpoint_identifier *identifier);
 
 /*!
  * \brief Unregister a SIP endpoint identifier
@@ -220,7 +220,7 @@ int ast_sip_register_endpoint_identifier(struct ast_sip_endpoint_identifier \*id
  *
  * \param identifier The SIP endoint identifier to unregister
  */
-void ast_sip_unregister_endpoint_identifier(struct ast_sip_endpoint_identifier \*identifier);
+void ast_sip_unregister_endpoint_identifier(struct ast_sip_endpoint_identifier *identifier);
 
 ```
 
@@ -242,14 +242,14 @@ c
  * \retval NULL Failure
  * \retval non-NULL Newly-created SIP work
  */
-struct ast_sip_work \*ast_sip_create_work(void);
+struct ast_sip_work *ast_sip_create_work(void);
 
 /*!
  * \brief Destroy a SIP work structure
  *
  * \param work The SIP work to destroy
  */
-void ast_sip_destroy_work(struct ast_sip_work \*work);
+void ast_sip_destroy_work(struct ast_sip_work *work);
 
 /*!
  * \brief Pushes a task into the SIP threadpool
@@ -262,7 +262,7 @@ void ast_sip_destroy_work(struct ast_sip_work \*work);
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_push_task(struct ast_sip_work \*work, int (\*sip_task)(void \*), void \*task_data);
+int ast_sip_push_task(struct ast_sip_work *work, int (*sip_task)(void *), void *task_data);
 
 ```
 
@@ -284,7 +284,7 @@ c
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_send_request(const char \*method, const char \*body, struct pjsip_dialog \*dlg);
+int ast_sip_send_request(const char *method, const char *body, struct pjsip_dialog *dlg);
 
 /*!
  * \brief Determine if an incoming request requires authentication
@@ -300,7 +300,7 @@ int ast_sip_send_request(const char \*method, const char \*body, struct pjsip_di
  * \retval non-zero The request requires authentication
  * \retval 0 The request does not require authentication
  */
-int ast_sip_requires_authentication(struct ast_sip_endpoint \*endpoint, struct pjsip_rx_data \*rdata);
+int ast_sip_requires_authentication(struct ast_sip_endpoint *endpoint, struct pjsip_rx_data *rdata);
 
 /*!
  * \brief Authenticate an inbound SIP request
@@ -317,7 +317,7 @@ int ast_sip_requires_authentication(struct ast_sip_endpoint \*endpoint, struct p
  * \retval 0 Successfully authenticated
  * \retval nonzero Failure to authenticate
  */
-int ast_sip_authenticate_request(struct ast_sip_endpoint \*endpoint, struct pjsip_rx_data \*rdata);
+int ast_sip_authenticate_request(struct ast_sip_endpoint *endpoint, struct pjsip_rx_data *rdata);
 
 /*!
  * \brief Get authentication credentials in order to challenge a request
@@ -330,7 +330,7 @@ int ast_sip_authenticate_request(struct ast_sip_endpoint \*endpoint, struct pjsi
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_get_authentication_credentials(struct ast_sip_endpoint \*endpoint, struct ast_sip_digest_challenge_data \*challenge);
+int ast_sip_get_authentication_credentials(struct ast_sip_endpoint *endpoint, struct ast_sip_digest_challenge_data *challenge);
 
 /*!
  * \brief Possible returns from ast_sip_check_authentication
@@ -359,7 +359,7 @@ enum ast_sip_check_auth_result {
  * \param rdata The request to potentially authenticate
  * \return The result of checking authentication.
  */
-ast_sip_check_authentication(struct ast_sip_endpoint \*endpoint, struct pjsip_rxdata \*rdata);
+ast_sip_check_authentication(struct ast_sip_endpoint *endpoint, struct pjsip_rxdata *rdata);
 
 /*!
  * \brief Challenge an inbound SIP request with a 401
@@ -372,7 +372,7 @@ ast_sip_check_authentication(struct ast_sip_endpoint \*endpoint, struct pjsip_rx
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_challenge_request(struct sip_digest_challenge_data \*challenge);
+int ast_sip_challenge_request(struct sip_digest_challenge_data *challenge);
 
 /*!
  * \brief Determine the endpoint that has sent a SIP message
@@ -386,7 +386,7 @@ int ast_sip_challenge_request(struct sip_digest_challenge_data \*challenge);
  * \retval NULL No matching endpoint
  * \retval non-NULL The matching endpoint
  */
-struct ast_sip_endpoint \*ast_sip_identify_endpoint(struct pjsip_rx_data \*rdata);
+struct ast_sip_endpoint *ast_sip_identify_endpoint(struct pjsip_rx_data *rdata);
 
 /*!
  * \brief Add a header to an outbound SIP message
@@ -397,7 +397,7 @@ struct ast_sip_endpoint \*ast_sip_identify_endpoint(struct pjsip_rx_data \*rdata
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_add_header(struct pjsip_tx_data \*tdata, const char \*name, const char \*value);
+int ast_sip_add_header(struct pjsip_tx_data *tdata, const char *name, const char *value);
 
 /*!
  * \brief Add a body to an outbound SIP message
@@ -410,7 +410,7 @@ int ast_sip_add_header(struct pjsip_tx_data \*tdata, const char \*name, const ch
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_add_body(struct pjsip_tx_data \*tdata, const char \*body);
+int ast_sip_add_body(struct pjsip_tx_data *tdata, const char *body);
 
 /*!
  * \brief Add a multipart body to an outbound SIP message
@@ -423,7 +423,7 @@ int ast_sip_add_body(struct pjsip_tx_data \*tdata, const char \*body);
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_add_body(struct pjsip_tx_data \*tdata, const char \*bodies[]);
+int ast_sip_add_body(struct pjsip_tx_data *tdata, const char *bodies[]);
 
 /*!
  * \brief Append body data to a SIP message
@@ -436,6 +436,6 @@ int ast_sip_add_body(struct pjsip_tx_data \*tdata, const char \*bodies[]);
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_append_body(struct pjsip_tx_data \*tdata, const char \*body);
+int ast_sip_append_body(struct pjsip_tx_data *tdata, const char *body);
 
 ```

--- a/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/New-SIP-Channel-Driver-Architecture/res_sip_session-design.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/New-SIP-Channel-Driver-Architecture/res_sip_session-design.md
@@ -37,11 +37,11 @@ c
  */
 struct ast_sip_session_cookie {
  /*! Callback used to destroy the cookie's data. Called when the cookie is removed from the sessio */
- void (\*destroy)(void \*cookie);
+ void (*destroy)(void *cookie);
  /*! Identifier for the cookie. Used when storing and retrieving a cooki */
- const char \*name;
+ const char *name;
  /*! Data associated with the cooki */
- void \*cookie_data;
+ void *cookie_data;
 };
 
 /*!
@@ -49,13 +49,13 @@ struct ast_sip_session_cookie {
  */
 struct ast_sip_session {
  /* The endpoint with which Asterisk is communicatin */
- struct ast_sip_endpoint \*endpoint;
+ struct ast_sip_endpoint *endpoint;
  /* The PJSIP details of the session, which includes the dialo */
- struct pjsip_inv_session \*inv_session;
+ struct pjsip_inv_session *inv_session;
  /* The Asterisk channel associated with the sessio */
- struct ast_channel \*channel;
+ struct ast_channel *channel;
  /* Cookies added to the session by supplements to the sessio */
- struct ao2_container \*cookies;
+ struct ao2_container *cookies;
 };
 
 /*!
@@ -66,23 +66,23 @@ struct ast_sip_session {
  */
 struct ast_sip_session_supplement {
  /*! Method on which to call the callbacks. If NULL, call on all method */
- const char \*method;
+ const char *method;
  /*! Notification that the session has begu */
- void (\*session_begin)(struct ast_sip_session \*session);
+ void (*session_begin)(struct ast_sip_session *session);
  /*! Notification that the session has ende */
- void (\*session_end)(struct ast_sip_session \*session);
+ void (*session_end)(struct ast_sip_session *session);
  /*!
  * \brief Called on incoming SIP request
  * This method can indicate a failure in processing in its return. If there
  * is a failure, it is required that this method sends a response to the request.
  */
- int (\*incoming_request)(struct ast_sip_session \*session, struct pjsip_rx_data \*rdata);
+ int (*incoming_request)(struct ast_sip_session *session, struct pjsip_rx_data *rdata);
  /*! Called on an incoming SIP respons */
- void (\*incoming_response)(struct ast_sip_session \*session, struct pjsip_rx_data \*rdata);
+ void (*incoming_response)(struct ast_sip_session *session, struct pjsip_rx_data *rdata);
  /*! Called on an outgoing SIP reques */
- void (\*outgoing_request)(struct ast_sip_session \*session, struct pjsip_tx_data \*tdata);
+ void (*outgoing_request)(struct ast_sip_session *session, struct pjsip_tx_data *tdata);
  /*! Called on an outgoing SIP respons */
- void (\*outgoing_response)(struct ast_sip_session \*session, struct pjsip_tx_data \*tdata);
+ void (*outgoing_response)(struct ast_sip_session *session, struct pjsip_tx_data *tdata);
 };
 
 /*!
@@ -100,7 +100,7 @@ struct ast_sip_session_sdp_handler {
  * \retval <0 There was an error encountered. No further operation will take place and the current negotiation will be abandoned.
  * \retval >0 The stream was handled by this handler. No further handler of this stream type will be called.
  */
- int (\*handle_incoming_sdp_stream_offer)(struct ast_sip_session \*session, struct pjmedia_sdp_media \*stream);
+ int (*handle_incoming_sdp_stream_offer)(struct ast_sip_session *session, struct pjmedia_sdp_media *stream);
  /*!
  * \brief Create an SDP media stream and add it to the outgoing SDP offer or answer
  * \param session The session for which media is being added
@@ -109,7 +109,7 @@ struct ast_sip_session_sdp_handler {
  * \retval <0 There was an error encountered. No further operation will take place and the current SDP negotiation will be abandoned.
  * \retval >0 The handler has a stream to be added to the SDP. No further handler of this stream type will be called.
  */
- int (\*create_outgoing_sdp_stream)(struct ast_sip_session \*session, struct pjmedia_sdp_session \*sdp);
+ int (*create_outgoing_sdp_stream)(struct ast_sip_session *session, struct pjmedia_sdp_session *sdp);
 };
 
 ```
@@ -135,14 +135,14 @@ c
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_session_register_sdp_handler(const struct ast_sip_session_sdp_handler \*handler, const char \*stream_type);
+int ast_sip_session_register_sdp_handler(const struct ast_sip_session_sdp_handler *handler, const char *stream_type);
 
 /*!
  * \brief Unregister an SDP handler
  *
  * \param handler The SDP handler to unregister
  */
-void ast_sip_session_unregister_sdp_handler(const struct ast_sip_session_sdp_handler \*handler);
+void ast_sip_session_unregister_sdp_handler(const struct ast_sip_session_sdp_handler *handler);
 
 /*!
  * \brief Register a supplement to SIP session processing
@@ -156,14 +156,14 @@ void ast_sip_session_unregister_sdp_handler(const struct ast_sip_session_sdp_han
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_session_register_supplement(struct ast_sip_session_supplement \*supplement);
+int ast_sip_session_register_supplement(struct ast_sip_session_supplement *supplement);
 
 /*!
  * \brief Unregister a an supplement to SIP session processing
  *
  * \param supplement The supplement to unregister
  */
-void ast_sip_session_unregister_supplement(struct ast_sip_session_supplement \*supplement);
+void ast_sip_session_unregister_supplement(struct ast_sip_session_supplement *supplement);
 
 /*!
  * \brief Add a cookie to a SIP session
@@ -172,7 +172,7 @@ void ast_sip_session_unregister_supplement(struct ast_sip_session_supplement \*s
  * \retval 0 Success
  * \retval -1 Failure
  */
-int ast_sip_session_add_cookie(struct ast_sip_session \*session, struct ast_sip_session_cookie \*cookie);
+int ast_sip_session_add_cookie(struct ast_sip_session *session, struct ast_sip_session_cookie *cookie);
 
 /*!
  * \brief Retrieve a session cookie
@@ -181,7 +181,7 @@ int ast_sip_session_add_cookie(struct ast_sip_session \*session, struct ast_sip_
  * \retval NULL Failed to find the specified cookie
  * \retval non-NULL The specified cookie
  */
-struct ast_sip_session_cookie \*ast_sip_session_get_cookie(struct ast_sip_session \*session, const char \*name);
+struct ast_sip_session_cookie *ast_sip_session_get_cookie(struct ast_sip_session *session, const char *name);
 
 /*!
  * \brief Remove a session cookie from the session
@@ -193,7 +193,7 @@ struct ast_sip_session_cookie \*ast_sip_session_get_cookie(struct ast_sip_sessio
  * \retval 0 Successfully removed the cookie
  * \retval -1 Failed to remove the cookie
  */
-int ast_sip_session_remove_cookie(struct ast_sip_session \*session, const char \*name);
+int ast_sip_session_remove_cookie(struct ast_sip_session *session, const char *name);
 
 ```
 
@@ -214,7 +214,7 @@ c
  * \retval 0 Successfully found identifying information
  * \retval -1 Identifying information could not be found
  */
-int ast_sip_session_get_identity(struct pjsip_rx_data \*rdata, struct ast_party_id \*id);
+int ast_sip_session_get_identity(struct pjsip_rx_data *rdata, struct ast_party_id *id);
 
 /*!
  * \brief Send a reinvite on a session
@@ -228,7 +228,7 @@ int ast_sip_session_get_identity(struct pjsip_rx_data \*rdata, struct ast_party_
  * \retval 0 Successfully sent reinvite
  * \retval -1 Failure to send reinvite
  */
-int ast_sip_session_send_reinvite(struct ast_sip_session \*session, int (\*response_cb)(struct ast_sip_session \*session, struct pjsip_rx_data \*rdata));
+int ast_sip_session_send_reinvite(struct ast_sip_session *session, int (*response_cb)(struct ast_sip_session *session, struct pjsip_rx_data *rdata));
 
 /*!
  * \brief Send a SIP response
@@ -240,6 +240,6 @@ int ast_sip_session_send_reinvite(struct ast_sip_session \*session, int (\*respo
  * \param response_code The response code to send for this response
  * \param rdata The response to which the response is being sent
  */
-int ast_sip_session_send_response(struct ast_sip_session \*session, int response_code, struct pjsip_rx_data \*rdata);
+int ast_sip_session_send_response(struct ast_sip_session *session, int response_code, struct pjsip_rx_data *rdata);
 
 ```

--- a/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/index.md
+++ b/docs/Development/Roadmap/Asterisk-12-Projects/New-SIP-channel-driver/index.md
@@ -35,7 +35,7 @@ As part of this work, pjproject has been pulled out of the Asterisk source tree 
 [//]: # (end-note)
 
 ```
-rm -f /usr/lib/libpj\*.a /usr/lib/libmilenage\*.a /usr/lib/pkgconfig/libpjproject.pc  
+rm -f /usr/lib/libpj*.a /usr/lib/libmilenage*.a /usr/lib/pkgconfig/libpjproject.pc  
 
 ---
 

--- a/docs/Development/Roadmap/Asterisk-13-Projects/Asterisk-13-ARI-Improvements/index.md
+++ b/docs/Development/Roadmap/Asterisk-13-Projects/Asterisk-13-ARI-Improvements/index.md
@@ -79,7 +79,7 @@ POST /endpoints/PJSIP/message
 {
  "from": "xmpp:bob@jabber.org",
  "to": "pjsip:generic/sip:alice@mysipserver.org"
- "body": "No, \*I\* am the very model of a major general"
+ "body": "No, *I* am the very model of a major general"
 }
 
 ```
@@ -126,9 +126,9 @@ There's a few pieces to the message core in Asterisk that will need to be change
 First, *message.h* will need to expose a registration function that allows for an external participant to handle the message routing:
 
 ```
-static int ast_msg_register_observer(const char \*id, void (\*msg_cb)(struct ast_msg \*msg));
+static int ast_msg_register_observer(const char *id, void (*msg_cb)(struct ast_msg *msg));
 
-static int ast_msg_unregister_observer(const char \*id);
+static int ast_msg_unregister_observer(const char *id);
 
 ```
 
@@ -142,10 +142,10 @@ When performing the routing (after pulling the message off the taskprocessor), m
  * \pre The message has already been set up on the msg datastore
  * on this channel.
  */
-static void msg_route(struct ast_channel \*chan, struct ast_msg \*msg)
+static void msg_route(struct ast_channel *chan, struct ast_msg *msg)
 {
  struct ast_pbx_args pbx_args;
- msg_cb_t \*cb;
+ msg_cb_t *cb;
 
  AST_LIST_TRAVERSE(&observers, cb, list) {
  cb(msg);

--- a/docs/Development/Roadmap/Asterisk-13-Projects/Media-Format-Rewrite.md
+++ b/docs/Development/Roadmap/Asterisk-13-Projects/Media-Format-Rewrite.md
@@ -307,9 +307,9 @@ struct ast_codec {
  /*! Original Asterisk identifier, optiona */
  uint64_t original_id;
  /*! Name for this code */
- const char \*name;
+ const char *name;
  /*! Brief descriptio */
- const char \*description;
+ const char *description;
  /*! Type of media this codec is fo */
  enum ast_format_type type;
  /*! Number of samples carrie */
@@ -325,14 +325,14 @@ struct ast_codec {
  /*! Whether the media can be smoothed or no */
  unsigned int smooth;
  /*! Callback function for getting the number of samples in a fram */
- int (\*get_samples)(struct ast_frame \*frame);
+ int (*get_samples)(struct ast_frame *frame);
  /*! Callback function for getting the length of media based on number of sample */
- int (\*get_length)(int samples);
+ int (*get_length)(int samples);
 };
 
-int ast_codec_register(struct ast_codec \*codec);
+int ast_codec_register(struct ast_codec *codec);
 
-struct ast_codec \*ast_codec_get(const char \*name, enum ast_format_type type, unsigned int samples);
+struct ast_codec *ast_codec_get(const char *name, enum ast_format_type type, unsigned int samples);
 
 ```
 
@@ -344,9 +344,9 @@ The ast_format structure will become an astobj2 allocated object as follows:
 
 ```
 struct ast_format {
- struct ast_codec \*codec;
- void \*attribute_data;
- struct ast_format_attr_interface \*interface;
+ struct ast_codec *codec;
+ void *attribute_data;
+ struct ast_format_attr_interface *interface;
 };
 
 ```
@@ -365,7 +365,7 @@ The ast_format_cap structure currently internally uses an ao2 hash table to stor
 
 ```
 struct ast_format_cap {
- AST_VECTOR(, struct ast_format \*) formats;
+ AST_VECTOR(, struct ast_format *) formats;
  AST_VECTOR(, int) framing;
  AST_VECTOR(, int) preference;
 };
@@ -412,7 +412,7 @@ For mapping from format to payload a vector with the format codec id as the inde
 For cases where a format has to be created a new API call, ast_format_create, which takes in a codec will be made available.
 
 ```
-struct ast_format \*ast_format_create(struct ast_codec \*codec);
+struct ast_format *ast_format_create(struct ast_codec *codec);
 
 ```
 
@@ -421,8 +421,8 @@ Example:
 ```
 static void example(void)
 {
- struct ast_codec \*codec = ast_codec_get("ulaw", AST_FORMAT_TYPE_AUDIO, 8000);
- struct ast_format \*format;
+ struct ast_codec *codec = ast_codec_get("ulaw", AST_FORMAT_TYPE_AUDIO, 8000);
+ struct ast_format *format;
 
  if (!codec) {
  return;
@@ -441,7 +441,7 @@ static void example(void)
 Attribute information can be set on a format by using the ast_format_attribute_set function. To keep things dynamic it takes in both a string for attribute name and value.
 
 ```
-int ast_format_attribute_set(struct ast_format \*format, const char \*attribute, const char \*value); 
+int ast_format_attribute_set(struct ast_format *format, const char *attribute, const char *value); 
 
 ```
 
@@ -450,8 +450,8 @@ Example:
 ```
 static void test_example(void)
 {
- struct ast_codec \*codec = ast_codec_get("silk", AST_FORMAT_TYPE_AUDIO, 8000);
- struct ast_format \*format;
+ struct ast_codec *codec = ast_codec_get("silk", AST_FORMAT_TYPE_AUDIO, 8000);
+ struct ast_format *format;
 
  if (!codec) {
  return;
@@ -485,7 +485,7 @@ static void test_example(void)
 The function to allocate a capabilities structure is unchanged but the format capabilities structure is now a reference counted object to reduce copying. As a result there is no explicit function to destroy a structure.
 
 ```
-struct ast_format_cap \*ast_format_cap_alloc(enum ast_format_cap_flags flags);
+struct ast_format_cap *ast_format_cap_alloc(enum ast_format_cap_flags flags);
 
 ```
 
@@ -494,7 +494,7 @@ Example:
 ```
 static void example(void)
 {
- struct ast_format_cap \*caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_NOLOCK);
+ struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_NOLOCK);
 
  ao2_ref(caps, -1);
 }
@@ -506,7 +506,7 @@ static void example(void)
 This is slightly changed from the existing API in that the format passed in is not const. The implementation also increments the reference count of the format instead of copying it.
 
 ```
-void ast_format_cap_add(struct ast_format_cap \*cap, struct ast_format \*format);
+void ast_format_cap_add(struct ast_format_cap *cap, struct ast_format *format);
 
 ```
 
@@ -515,9 +515,9 @@ Example:
 ```
 static void example(void)
 {
- struct ast_codec \*codec = ast_codec_get("ulaw", AST_FORMAT_TYPE_AUDIO, 8000);
- struct ast_format \*format;
- struct ast_format_cap \*caps;
+ struct ast_codec *codec = ast_codec_get("ulaw", AST_FORMAT_TYPE_AUDIO, 8000);
+ struct ast_format *format;
+ struct ast_format_cap *caps;
 
  if (!codec) {
  return;
@@ -554,15 +554,15 @@ static void example(void)
 Numerous functions manipulate the capabilities structure itself. These are used to copy formats between structures, duplicate them, etc. These will go unchanged except internally they will no longer duplicate the format. Instead they will increment the reference count.
 
 ```
-void ast_format_cap_add_all_by_type(struct ast_format_cap \*cap, enum ast_format_type type);
-void ast_format_cap_add_all(struct ast_format_cap \*cap);
-void ast_format_cap_append(struct ast_format_cap \*dst, const struct ast_format_cap \*src);
-void ast_format_cap_copy(struct ast_format_cap \*dst, const struct ast_format_cap \*src);
-struct ast_format_cap \*ast_format_cap_dup(const struct ast_format_cap \*src);
-int ast_format_cap_is_empty(const struct ast_format_cap \*cap);
-int ast_format_cap_remove(struct ast_format_cap \*cap, struct ast_format \*format);
-void ast_format_cap_remove_bytype(struct ast_format_cap \*cap, enum ast_format_type type);
-void ast_format_cap_remove_all(struct ast_format_cap \*cap);
+void ast_format_cap_add_all_by_type(struct ast_format_cap *cap, enum ast_format_type type);
+void ast_format_cap_add_all(struct ast_format_cap *cap);
+void ast_format_cap_append(struct ast_format_cap *dst, const struct ast_format_cap *src);
+void ast_format_cap_copy(struct ast_format_cap *dst, const struct ast_format_cap *src);
+struct ast_format_cap *ast_format_cap_dup(const struct ast_format_cap *src);
+int ast_format_cap_is_empty(const struct ast_format_cap *cap);
+int ast_format_cap_remove(struct ast_format_cap *cap, struct ast_format *format);
+void ast_format_cap_remove_bytype(struct ast_format_cap *cap, enum ast_format_type type);
+void ast_format_cap_remove_all(struct ast_format_cap *cap);
 
 ```
 
@@ -571,8 +571,8 @@ void ast_format_cap_remove_all(struct ast_format_cap \*cap);
 As the capabilities structure is now stored using an array iteration will involve two functions, ast_format_cap_count and ast_format_cap_get, which returns the number of formats in the structure and gets a specific one based on index.
 
 ```
-size_t ast_format_cap_count(const struct ast_format_cap \*cap);
-struct ast_format \*ast_format_cap_get(const struct ast_format_cap \*cap, int index);
+size_t ast_format_cap_count(const struct ast_format_cap *cap);
+struct ast_format *ast_format_cap_get(const struct ast_format_cap *cap, int index);
 
 ```
 
@@ -581,7 +581,7 @@ Example:
 ```
 static void example(void)
 {
- struct ast_format_cap \*caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_NOLOCK);
+ struct ast_format_cap *caps = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_NOLOCK);
  size_t count;
  int index;
 
@@ -590,7 +590,7 @@ static void example(void)
  }
 
  for (count = ast_format_cap_count(caps), index = 0; index < count; index++) {
- struct ast_format \*format = ast_format_cap_get(caps, index);
+ struct ast_format *format = ast_format_cap_get(caps, index);
 
  ao2_ref(format, -1);
  }
@@ -605,8 +605,8 @@ static void example(void)
 The framing size controls the length of media frames (in milliseconds). Previously this was stored in a separate structure but has now been rolled into ast_format_cap. To allow control two API calls will be added.
 
 ```
-void ast_format_cap_framing_set(struct ast_format_cap \*cap, const struct ast_format \*format, unsigned int framing);
-unsigned int ast_format_cap_framing_get(const struct ast_format_cap \*cap, const struct ast_format \*format);
+void ast_format_cap_framing_set(struct ast_format_cap *cap, const struct ast_format *format, unsigned int framing);
+unsigned int ast_format_cap_framing_get(const struct ast_format_cap *cap, const struct ast_format *format);
 
 ```
 
@@ -615,9 +615,9 @@ Example:
 ```
 static void example(void)
 {
- struct ast_codec \*codec = ast_codec_get("ulaw", AST_FORMAT_TYPE_AUDIO, 8000);
- struct ast_format \*format;
- struct ast_format_cap \*caps;
+ struct ast_codec *codec = ast_codec_get("ulaw", AST_FORMAT_TYPE_AUDIO, 8000);
+ struct ast_format *format;
+ struct ast_format_cap *caps;
  unsigned int framing;
 
  if (!codec) {
@@ -652,9 +652,9 @@ static void example(void)
 Joint capabilities are the common compatible formats between two capabilities structure. These will be done using the existing API functions but will now take preference order into consideration. This will be done by using the order of the first capabilities structure passed in.
 
 ```
-struct ast_format_cap \*ast_format_cap_joint(const struct ast_format_cap \*cap_preferred, const struct ast_format_cap \*cap_secondary);
-int ast_format_cap_joint_copy(const struct ast_format_cap \*cap1, const struct ast_format_cap \*cap2, struct ast_format_cap \*result);
-int ast_format_cap_joint_append(const struct ast_format_cap \*cap1, const struct ast_format_cap \*cap2, struct ast_format_cap \*result);
+struct ast_format_cap *ast_format_cap_joint(const struct ast_format_cap *cap_preferred, const struct ast_format_cap *cap_secondary);
+int ast_format_cap_joint_copy(const struct ast_format_cap *cap1, const struct ast_format_cap *cap2, struct ast_format_cap *result);
+int ast_format_cap_joint_append(const struct ast_format_cap *cap1, const struct ast_format_cap *cap2, struct ast_format_cap *result);
 
 ```
 
@@ -663,43 +663,42 @@ Example:
 ```
 static void example(void)
 {
- struct ast_codec \*codec = ast_codec_get("ulaw", AST_FORMAT_TYPE_AUDIO, 8000);
- struct ast_format \*format;
- struct ast_format_cap \*caps0, \*caps1, \*joint;
+	struct ast_codec *codec = ast_codec_get("ulaw", AST_FORMAT_TYPE_AUDIO, 8000);
+	struct ast_format *format;
+	struct ast_format_cap *caps0, *caps1, *joint;
 
- if (!codec) {
- return;
- }
+	if (!codec) {
+		return;
+	}
 
- format = ast_format_create(codec);
- ao2_ref(codec, -1);
+	format = ast_format_create(codec);
+	ao2_ref(codec, -1);
 
- if (!format) {
- return;
- }
+	if (!format) {
+		return;
+	}
 
- caps0 = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_NOLOCK);
- if (!caps0) {
- ao2_ref(format, -1);
- return;
- }
+	caps0 = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_NOLOCK);
+	if (!caps0) {
+		ao2_ref(format, -1);
+		return;
+	}
 
- ast_format_cap_add(caps0, format);
- ao2_ref(format, -1);
+	ast_format_cap_add(caps0, format);
+	ao2_ref(format, -1);
 
- caps1 = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_NOLOCK);
- if (!caps1) {
- ao2_ref(caps0, -1);
- return;
- }
+	caps1 = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_NOLOCK);
+	if (!caps1) {
+		ao2_ref(caps0, -1);
+		return;
+	}
 
- ast_format_cap_copy(caps1, caps0);
+	ast_format_cap_copy(caps1, caps0);
 
- joint = ast_format_cap_joint(caps0, caps1);
+	joint = ast_format_cap_joint(caps0, caps1);
 
- ao2_cleanup(joint);
- ao2_ref(caps0, -1);
- ao2_ref(caps1, -1);
+	ao2_cleanup(joint);
+	ao2_ref(caps0, -1);
+	ao2_ref(caps1, -1);
 }
-
 ```

--- a/docs/Development/Roadmap/Asterisk-13-Projects/Resource-List-Subscriptions/index.md
+++ b/docs/Development/Roadmap/Asterisk-13-Projects/Resource-List-Subscriptions/index.md
@@ -80,7 +80,7 @@ An RLMI document can be constructed using the following structure:
 
 ```
 struct rlmi_data {
- struct ast_sip_subscription \*list_subscription;
+ struct ast_sip_subscription *list_subscription;
  AST_LIST_HEAD(,ast_list_subscription) child_subscriptions;
 };
 

--- a/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-14-Project-URI-Media-Playback.md
+++ b/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-14-Project-URI-Media-Playback.md
@@ -198,7 +198,7 @@ cpp/*
  * \retval 0 The item is not in the cache
  * \retval 1 The item is in the cache
  */
-int ast_media_cache_exists(const char \*uri);
+int ast_media_cache_exists(const char *uri);
 
 /*
  * \brief Retrieve media from a URI or in the cache
@@ -212,7 +212,7 @@ int ast_media_cache_exists(const char \*uri);
  * \retval 0 on success
  * \retval -1 on error
  */
-int ast_media_cache_retrieve(const char \*uri, const char \*preferred_file_name, char \*file_path, size_t len);
+int ast_media_cache_retrieve(const char *uri, const char *preferred_file_name, char *file_path, size_t len);
 
 /*!
  * \brief Update an item in the cache
@@ -224,7 +224,7 @@ int ast_media_cache_retrieve(const char \*uri, const char \*preferred_file_name,
  * \retval 0 success
  * \retval -1 error
  */
-int ast_media_cache_create_or_update(const char \*uri, const char \*file_path, struct ast_variable \*metadata);
+int ast_media_cache_create_or_update(const char *uri, const char *file_path, struct ast_variable *metadata);
 
 /*
  * \brief Remove an item from the cache
@@ -234,7 +234,7 @@ int ast_media_cache_create_or_update(const char \*uri, const char \*file_path, s
  * \retval 0 success
  * \retval -1 error
  */
-int ast_media_cache_delete(const char \*uri);
+int ast_media_cache_delete(const char *uri);
 
 ```
 
@@ -245,7 +245,7 @@ int ast_media_cache_delete(const char \*uri);
 Just for fun! It'd be good to see what is in the cache, the timestamps, etc.
 
 ```
-\*CLI>core show media-cache
+*CLI>core show media-cache
 
 URI Last update Local file
 http://myserver.com/awesome.wav 2014-10-30 00:52:25 UTC /var/spool/asterisk/media_cache/ahsd98d1.wav
@@ -263,11 +263,11 @@ Note that the last two files would have been created using a preferred file pref
 This is really a handy way for a system administrator to force files to be pulled down.
 
 ```
-\*CLI>core clear media-cache
+*CLI>core clear media-cache
 
 3 items purged.
 
-\*CLI>core show media-cache
+*CLI>core show media-cache
 
 URI Last update Local file
 0 items found.
@@ -323,7 +323,7 @@ Support for a new Content-Type, `text/uri-list`, needs to be added to the HTTP s
  * \retval NULL on error or a body not encoded as text/uri-list
  * \retval A list of URIs. This an ao2 object that must be disposed of by the caller of the function.
  */
-struct ast_uri_list \*ast_http_get_uri_list(struct ast_tcptls_session_instance \*ser, struct ast_variable \*headers);
+struct ast_uri_list *ast_http_get_uri_list(struct ast_tcptls_session_instance *ser, struct ast_variable *headers);
 
 ```
 
@@ -337,7 +337,7 @@ struct ast_uri_list \*ast_http_get_uri_list(struct ast_tcptls_session_instance \
  *
  * \retval The string representation of the URI.
  */
-const char \*ast_uri_to_string(struct ast_uri \*uri);
+const char *ast_uri_to_string(struct ast_uri *uri);
 
 struct ast_uri_list;
 struct ast_uri_list_iterator;
@@ -348,14 +348,14 @@ struct ast_uri_list_iterator;
  * \retval A new \c ast_uri_list on success. This is an ao2 object.
  * \retval NULL on error
  */
-struct ast_uri_list \*ast_uri_list_create(void);
+struct ast_uri_list *ast_uri_list_create(void);
 
 /*!
  * \brief Append a \c ast_uri to a \c ast_uri_list
  *
  * \param uri The \c ast_uri to append
  */
-void ast_uri_list_append(struct ast_uri \*uri);
+void ast_uri_list_append(struct ast_uri *uri);
 
 /*!
  * \brief Create an iterator for a \c ast_uri_list
@@ -365,14 +365,14 @@ void ast_uri_list_append(struct ast_uri \*uri);
  * \retval A \c ast_uri_list_iterator on success
  * \retval NULL on error
  */
-struct ast_uri_list_iterator \*ast_uri_list_iterator_create(struct ast_uri_list \*uri_list);
+struct ast_uri_list_iterator *ast_uri_list_iterator_create(struct ast_uri_list *uri_list);
 
 /*!
  * \brief Dispose of a \c ast_uri_list_iterator
  *
  * \param iterator The \c ast_uri_list_iterator to destroy
  */
-void ast_uri_list_iterator_destroy(struct ast_uri_list_iterator \*iterator);
+void ast_uri_list_iterator_destroy(struct ast_uri_list_iterator *iterator);
 
 /*!
  * \brief Retrieve the next \c ast_uri in an \c ast_uri_list
@@ -382,7 +382,7 @@ void ast_uri_list_iterator_destroy(struct ast_uri_list_iterator \*iterator);
  * \retval NULL if no more items in the list
  * \retval The next \c ast_uri otherwise
  */
-struct ast_uri \*ast_uri_list_iterator_next(struct ast_uri_list_iterator \*iterator);
+struct ast_uri *ast_uri_list_iterator_next(struct ast_uri_list_iterator *iterator);
 
 ```
 

--- a/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-Beacon-Module.md
+++ b/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-Beacon-Module.md
@@ -455,7 +455,7 @@ When logging is enabled, the CLI will display - as the last thing that is displa
  Asterisk Malloc Debugger Started (see /var/log/asterisk/mmlog))
 [Dec 29 16:10:59] NOTICE[13489]: res_beacon.c:103 load_module: <<< <<< <<< ANONYMOUS USAGE STATISTICS ENABLED >>> >>> >>>
 Asterisk Ready.
-\*CLI>
+*CLI>
 
 ```
 
@@ -507,7 +507,7 @@ CLI Commands
 Display the gathered information about the server. This should show what we would send in a server update request.
 
 ```
- \*CLI> beacon show server
+ *CLI> beacon show server
 
 Server ID: bc5829cc-4584-43e5-8395-a9b1206d7e02
 Token:

--- a/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-DNS-API/DNS-NAPTRSRV-Test-Plan-for-PJSIP.md
+++ b/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-DNS-API/DNS-NAPTRSRV-Test-Plan-for-PJSIP.md
@@ -318,7 +318,7 @@ Procedure:
 
 ```
 ; order pref flags service regexp replacement
-IN NAPTR 50 50 "s" "SIP+D2T" "!.\*!_sip._tcp.test.internal!" .
+IN NAPTR 50 50 "s" "SIP+D2T" "!.*!_sip._tcp.test.internal!" .
 IN NAPTR 60 50 "s" "SIP+D2U" "" _sip._udp.test.internal.
 
 ```

--- a/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-DNS-API/index.md
+++ b/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-DNS-API/index.md
@@ -46,7 +46,7 @@ struct ast_dns_query;
  *
  * \return the name queried
  */
-const char \*ast_dns_query_get_name(const struct ast_dns_query \*query);
+const char *ast_dns_query_get_name(const struct ast_dns_query *query);
 /*!
  * \brief Get the record resource type of a DNS query
  *
@@ -54,7 +54,7 @@ const char \*ast_dns_query_get_name(const struct ast_dns_query \*query);
  *
  * \return the record resource type
  */
-int ast_dns_query_get_rr_type(const struct ast_dns_query \*query);
+int ast_dns_query_get_rr_type(const struct ast_dns_query *query);
 /*!
  * \brief Get the record resource class of a DNS query
  *
@@ -62,7 +62,7 @@ int ast_dns_query_get_rr_type(const struct ast_dns_query \*query);
  *
  * \return the record resource class
  */
-int ast_dns_query_get_rr_class(const struct ast_dns_query \*query);
+int ast_dns_query_get_rr_class(const struct ast_dns_query *query);
 /*!
  * \brief Get the error rcode of a DNS query
  *
@@ -70,7 +70,7 @@ int ast_dns_query_get_rr_class(const struct ast_dns_query \*query);
  *
  * \return the DNS rcode
  */
-int ast_dns_query_get_rcode(const struct ast_dns_query \*query);
+int ast_dns_query_get_rcode(const struct ast_dns_query *query);
 /*!
  * \brief Get the user specific data of a DNS query
  *
@@ -78,7 +78,7 @@ int ast_dns_query_get_rcode(const struct ast_dns_query \*query);
  *
  * \return the user specific data
  */
-void \*ast_dns_query_get_data(const struct ast_dns_query \*query);
+void *ast_dns_query_get_data(const struct ast_dns_query *query);
 /*! \brief Opaque structure for a DNS query resul */
 struct ast_dns_result;
 /*!
@@ -88,7 +88,7 @@ struct ast_dns_result;
  *
  * \return the DNS result information
  */
-struct ast_dns_result \*ast_dns_query_get_result(const struct ast_dns_query \*query);
+struct ast_dns_result *ast_dns_query_get_result(const struct ast_dns_query *query);
 /*!
  * \brief Get whether the domain exists or not
  *
@@ -96,7 +96,7 @@ struct ast_dns_result \*ast_dns_query_get_result(const struct ast_dns_query \*qu
  *
  * \return whether the domain exists or not
  */
-unsigned int ast_dns_result_get_nxdomain(const struct ast_dns_result \*result);
+unsigned int ast_dns_result_get_nxdomain(const struct ast_dns_result *result);
 /*!
  * \brief Get whether the result is secure or not
  *
@@ -104,7 +104,7 @@ unsigned int ast_dns_result_get_nxdomain(const struct ast_dns_result \*result);
  *
  * \return whether the result is secure or not
  */
-unsigned int ast_dns_result_get_secure(const struct ast_dns_result \*result);
+unsigned int ast_dns_result_get_secure(const struct ast_dns_result *result);
 /*!
  * \brief Get whether the result is bogus or not
  *
@@ -112,7 +112,7 @@ unsigned int ast_dns_result_get_secure(const struct ast_dns_result \*result);
  *
  * \return whether the result is bogus or not
  */
-unsigned int ast_dns_result_get_bogus(const struct ast_dns_result \*result);
+unsigned int ast_dns_result_get_bogus(const struct ast_dns_result *result);
 /*!
  * \brief Get the canonical name of the result
  *
@@ -120,7 +120,7 @@ unsigned int ast_dns_result_get_bogus(const struct ast_dns_result \*result);
  *
  * \return the canonical name
  */
-const char \*ast_dns_result_get_canonical(const struct ast_dns_result \*result);
+const char *ast_dns_result_get_canonical(const struct ast_dns_result *result);
 /*!
  * \brief Get the first record of a DNS Result
  *
@@ -128,13 +128,13 @@ const char \*ast_dns_result_get_canonical(const struct ast_dns_result \*result);
  *
  * \return first DNS record
  */
-const struct ast_dns_record \*ast_dns_result_get_records(const struct ast_dns_result \*result);
+const struct ast_dns_record *ast_dns_result_get_records(const struct ast_dns_result *result);
 /*!
  * \brief Free the DNS result information
  *
  * \param result The DNS result
  */
-void ast_dns_result_free(struct ast_dns_result \*result);
+void ast_dns_result_free(struct ast_dns_result *result);
 /*! \brief Opaque structure for a DNS recor */
 struct ast_dns_record;
 /*!
@@ -142,7 +142,7 @@ struct ast_dns_record;
  *
  * \param query The DNS query that was invoked
  */
-typedef void (\*ast_dns_resolve_callback)(const struct ast_dns_query \*query);
+typedef void (*ast_dns_resolve_callback)(const struct ast_dns_query *query);
 /*!
  * \brief Get the resource record type of a DNS record
  *
@@ -150,7 +150,7 @@ typedef void (\*ast_dns_resolve_callback)(const struct ast_dns_query \*query);
  *
  * \return the resource record type
  */
-int ast_dns_record_get_rr_type(const struct ast_dns_record \*record);
+int ast_dns_record_get_rr_type(const struct ast_dns_record *record);
 /*!
  * \brief Get the resource record class of a DNS record
  *
@@ -158,7 +158,7 @@ int ast_dns_record_get_rr_type(const struct ast_dns_record \*record);
  *
  * \return the resource record class
  */
-int ast_dns_record_get_rr_class(const struct ast_dns_record \*record);
+int ast_dns_record_get_rr_class(const struct ast_dns_record *record);
 /*!
  * \brief Get the TTL of a DNS record
  *
@@ -166,7 +166,7 @@ int ast_dns_record_get_rr_class(const struct ast_dns_record \*record);
  *
  * \return the TTL
  */
-int ast_dns_record_get_ttl(const struct ast_dns_record \*record);
+int ast_dns_record_get_ttl(const struct ast_dns_record *record);
 /*!
  * \brief Retrieve the raw DNS record
  *
@@ -174,7 +174,7 @@ int ast_dns_record_get_ttl(const struct ast_dns_record \*record);
  *
  * \return the raw DNS record
  */
-const char \*ast_dns_record_get_data(const struct ast_dns_record \*record);
+const char *ast_dns_record_get_data(const struct ast_dns_record *record);
 /*!
  * \brief Get the next DNS record
  *
@@ -182,7 +182,7 @@ const char \*ast_dns_record_get_data(const struct ast_dns_record \*record);
  *
  * \return the next DNS record
  */
-struct ast_dns_record \*ast_dns_record_get_next(const struct ast_dns_record \*record);
+struct ast_dns_record *ast_dns_record_get_next(const struct ast_dns_record *record);
 /*!
  * \brief Asynchronously resolve a DNS query
  *
@@ -197,7 +197,7 @@ struct ast_dns_record \*ast_dns_record_get_next(const struct ast_dns_record \*re
  *
  * \note The result passed to the callback does not need to be freed
  */
-struct ast_dns_query \*ast_dns_resolve_async(const char \*name, int rr_type, int rr_class, ast_dns_resolve_callback callback, void \*data);
+struct ast_dns_query *ast_dns_resolve_async(const char *name, int rr_type, int rr_class, ast_dns_resolve_callback callback, void *data);
 /*!
  * \brief Asynchronously resolve a DNS query, and continue resolving it according to the lowest TTL available
  *
@@ -216,7 +216,7 @@ struct ast_dns_query \*ast_dns_resolve_async(const char \*name, int rr_type, int
  *
  * \note It is NOT possible for the callback to be invoked concurrently for the query multiple times
  */
-struct ast_dns_query \*ast_dns_resolve_async_recurring(const char \*name, int rr_type, int rr_class, ast_dns_resolve_callback callback, void \*data);
+struct ast_dns_query *ast_dns_resolve_async_recurring(const char *name, int rr_type, int rr_class, ast_dns_resolve_callback callback, void *data);
 /*!
  * \brief Cancel an asynchronous DNS resolution
  *
@@ -227,7 +227,7 @@ struct ast_dns_query \*ast_dns_resolve_async_recurring(const char \*name, int rr
  *
  * \note If successfully cancelled the callback will not be invoked
  */
-int ast_dns_resolve_cancel(struct ast_dns_query \*query);
+int ast_dns_resolve_cancel(struct ast_dns_query *query);
 /*!
  * \brief Synchronously resolve a DNS query
  *
@@ -239,7 +239,7 @@ int ast_dns_resolve_cancel(struct ast_dns_query \*query);
  * \retval 0 success - query was completed and result is available
  * \retval -1 failure
  */
-int ast_dns_resolve(const char \*name, int rr_type, int rr_class, struct ast_dns_result \*\*result);
+int ast_dns_resolve(const char *name, int rr_type, int rr_class, struct ast_dns_result **result);
 
 ```
 
@@ -261,14 +261,14 @@ struct ast_dns_query_set;
  *
  * \param query_set The DNS query set that was invoked
  */
-typedef void (\*ast_dns_query_set_callback)(const struct ast_dns_query_set \*query_set);
+typedef void (*ast_dns_query_set_callback)(const struct ast_dns_query_set *query_set);
 /*!
  * \brief Create a query set to hold queries
  *
  * \retval non-NULL success
  * \retval NULL failure
  */
-struct ast_dns_query_set \*ast_dns_query_set_create(void);
+struct ast_dns_query_set *ast_dns_query_set_create(void);
 /*!
  * \brief Add a query to a query set
  *
@@ -280,7 +280,7 @@ struct ast_dns_query_set \*ast_dns_query_set_create(void);
  * \retval 0 success
  * \retval -1 failure
  */
-int ast_dns_query_set_add(struct ast_dns_query_set \*query_set, const char \*name, int rr_type, int rr_class);
+int ast_dns_query_set_add(struct ast_dns_query_set *query_set, const char *name, int rr_type, int rr_class);
 /*!
  * \brief Retrieve the number of queries in a query set
  *
@@ -288,7 +288,7 @@ int ast_dns_query_set_add(struct ast_dns_query_set \*query_set, const char \*nam
  *
  * \return the number of queries
  */
-size_t ast_dns_query_set_num_queries(const struct ast_dns_query_set \*query_set);
+size_t ast_dns_query_set_num_queries(const struct ast_dns_query_set *query_set);
 /*!
  * \brief Retrieve a query from a query set
  *
@@ -298,7 +298,7 @@ size_t ast_dns_query_set_num_queries(const struct ast_dns_query_set \*query_set)
  * \retval non-NULL success
  * \retval NULL failure
  */
-struct ast_dns_query \*ast_dns_query_set_get(const struct ast_dns_query_set \*query_set, unsigned int index);
+struct ast_dns_query *ast_dns_query_set_get(const struct ast_dns_query_set *query_set, unsigned int index);
 /*!
  * \brief Retrieve user specific data from a query set
  *
@@ -306,7 +306,7 @@ struct ast_dns_query \*ast_dns_query_set_get(const struct ast_dns_query_set \*qu
  *
  * \return user specific data
  */
-void \*ast_dns_query_set_get_data(const struct ast_dns_query_set \*query_set);
+void *ast_dns_query_set_get_data(const struct ast_dns_query_set *query_set);
 /*!
  * \brief Asynchronously resolve queries in a query set
  *
@@ -318,7 +318,7 @@ void \*ast_dns_query_set_get_data(const struct ast_dns_query_set \*query_set);
  *
  * \note The user data passed in to this function must be ao2 allocated
  */
-void ast_dns_query_set_resolve_async(struct ast_dns_query_set \*query_set, ast_dns_query_set_callback callback, void \*data);
+void ast_dns_query_set_resolve_async(struct ast_dns_query_set *query_set, ast_dns_query_set_callback callback, void *data);
 /*!
  * \brief Synchronously resolve queries in a query set
  *
@@ -326,7 +326,7 @@ void ast_dns_query_set_resolve_async(struct ast_dns_query_set \*query_set, ast_d
  *
  * \note This function will return when all queries have been completed
  */
-void ast_query_set_resolve(struct ast_dns_query_set \*query_set);
+void ast_query_set_resolve(struct ast_dns_query_set *query_set);
 /*!
  * \brief Cancel an asynchronous DNS query set resolution
  *
@@ -337,13 +337,13 @@ void ast_query_set_resolve(struct ast_dns_query_set \*query_set);
  *
  * \note If successfully cancelled the callback will not be invoked
  */
-int ast_dns_query_set_resolve_cancel(struct ast_dns_query_set \*query_set);
+int ast_dns_query_set_resolve_cancel(struct ast_dns_query_set *query_set);
 /*!
  * \brief Free a query set
  *
  * \param query_set A DNS query set
  */
-void ast_dns_query_set_free(struct ast_dns_query_set \*query_set);
+void ast_dns_query_set_free(struct ast_dns_query_set *query_set);
 
 ```
 
@@ -363,7 +363,7 @@ Code
  *
  * \return the flags
  */
-const char \*ast_dns_naptr_get_flags(const struct ast_dns_record \*record);
+const char *ast_dns_naptr_get_flags(const struct ast_dns_record *record);
 /*!
  * \brief Get the service from a NAPTR record
  *
@@ -371,7 +371,7 @@ const char \*ast_dns_naptr_get_flags(const struct ast_dns_record \*record);
  *
  * \return the service
  */
-const char \*ast_dns_naptr_get_service(const struct ast_dns_record \*record);
+const char *ast_dns_naptr_get_service(const struct ast_dns_record *record);
 /*!
  * \brief Get the regular expression from a NAPTR record
  *
@@ -379,7 +379,7 @@ const char \*ast_dns_naptr_get_service(const struct ast_dns_record \*record);
  *
  * \return the regular expression
  */
-const char \*ast_dns_naptr_get_regexp(const struct ast_dns_record \*record);
+const char *ast_dns_naptr_get_regexp(const struct ast_dns_record *record);
 /*!
  * \brief Get the replacement value from a NAPTR record
  *
@@ -387,7 +387,7 @@ const char \*ast_dns_naptr_get_regexp(const struct ast_dns_record \*record);
  *
  * \return the replacement value
  */
-const char \*ast_dns_naptr_get_replacement(const struct ast_dns_record \*record);
+const char *ast_dns_naptr_get_replacement(const struct ast_dns_record *record);
 /*!
  * \brief Get the order from a NAPTR record
  *
@@ -395,7 +395,7 @@ const char \*ast_dns_naptr_get_replacement(const struct ast_dns_record \*record)
  *
  * \return the order
  */
-unsigned short ast_dns_naptr_get_order(const struct ast_dns_record \*record);
+unsigned short ast_dns_naptr_get_order(const struct ast_dns_record *record);
 /*!
  * \brief Get the preference from a NAPTR record
  *
@@ -403,7 +403,7 @@ unsigned short ast_dns_naptr_get_order(const struct ast_dns_record \*record);
  *
  * \return the preference
  */
-unsigned short ast_dns_naptr_get_preference(const struct ast_dns_record \*record);
+unsigned short ast_dns_naptr_get_preference(const struct ast_dns_record *record);
 
 ```
 
@@ -423,7 +423,7 @@ Code
  *
  * \return the hostname
  */
-const char \*ast_dns_srv_get_host(const struct ast_dns_record \*record);
+const char *ast_dns_srv_get_host(const struct ast_dns_record *record);
 /*!
  * \brief Get the priority from an SRV record
  *
@@ -431,7 +431,7 @@ const char \*ast_dns_srv_get_host(const struct ast_dns_record \*record);
  *
  * \return the priority
  */
-unsigned short ast_dns_srv_get_priority(const struct ast_dns_record \*record);
+unsigned short ast_dns_srv_get_priority(const struct ast_dns_record *record);
 /*!
  * \brief Get the weight from an SRV record
  *
@@ -439,7 +439,7 @@ unsigned short ast_dns_srv_get_priority(const struct ast_dns_record \*record);
  *
  * \return the weight
  */
-unsigned short ast_dns_srv_get_weight(const struct ast_dns_record \*record);
+unsigned short ast_dns_srv_get_weight(const struct ast_dns_record *record);
 /*!
  * \brief Get the port from an SRV record
  *
@@ -447,7 +447,7 @@ unsigned short ast_dns_srv_get_weight(const struct ast_dns_record \*record);
  *
  * \return the port
  */
-unsigned short ast_dns_srv_get_port(const struct ast_dns_record \*record);
+unsigned short ast_dns_srv_get_port(const struct ast_dns_record *record);
 
 ```
 
@@ -464,7 +464,7 @@ The dns_tlsa.h file is the public API into accessing TLSA records.
  *
  * \return the certificate usage field
  */
-unsigned int ast_dns_tlsa_get_usage(const struct ast_dns_record \*record);
+unsigned int ast_dns_tlsa_get_usage(const struct ast_dns_record *record);
 /*!
  * \brief Get the selector field from a TLSA record
  *
@@ -472,7 +472,7 @@ unsigned int ast_dns_tlsa_get_usage(const struct ast_dns_record \*record);
  *
  * \return the selector field
  */
-unsigned int ast_dns_tlsa_get_selector(const struct ast_dns_record \*record);
+unsigned int ast_dns_tlsa_get_selector(const struct ast_dns_record *record);
 /*!
  * \brief Get the matching type field from a TLSA record
  *
@@ -480,7 +480,7 @@ unsigned int ast_dns_tlsa_get_selector(const struct ast_dns_record \*record);
  *
  * \return the matching type field
  */
-unsigned int ast_dns_tlsa_get_matching_type(const struct ast_dns_record \*record);
+unsigned int ast_dns_tlsa_get_matching_type(const struct ast_dns_record *record);
 /*!
  * \brief Get the certificate association data from a TLSA record
  *
@@ -488,7 +488,7 @@ unsigned int ast_dns_tlsa_get_matching_type(const struct ast_dns_record \*record
  *
  * \return the certificate association data
  */
-const char \*ast_dns_tlsa_get_association_data(const struct ast_dns_record \*record);
+const char *ast_dns_tlsa_get_association_data(const struct ast_dns_record *record);
 
 ```
 
@@ -504,13 +504,13 @@ Code
 /*! \brief DNS resolver implementatio */
 struct ast_dns_resolver {
  /*! \brief The name of the resolver implementatio */
- const char \*name;
+ const char *name;
  /*! \brief Priority for this resolver if multiple exis */
  unsigned int priority;
  /*! \brief Perform resolution of a DNS quer */
- int (\*resolve)(struct ast_dns_query \*query);
+ int (*resolve)(struct ast_dns_query *query);
  /*! \brief Cancel resolution of a DNS quer */
- int (\*cancel)(struct ast_dns_query \*query);
+ int (*cancel)(struct ast_dns_query *query);
 };
 /*!
  * \brief Set resolver specific data on a query
@@ -520,7 +520,7 @@ struct ast_dns_resolver {
  *
  * \note Unlike user specific data this does not have to be ao2 allocated
  */
-void ast_dns_resolver_set_data(struct ast_dns_query \*query, void \*data);
+void ast_dns_resolver_set_data(struct ast_dns_query *query, void *data);
 /*!
  * \brief Retrieve resolver specific data
  *
@@ -528,7 +528,7 @@ void ast_dns_resolver_set_data(struct ast_dns_query \*query, void \*data);
  *
  * \return the resolver specific data
  */
-void \*ast_dns_resolver_get_data(const struct ast_dns_query \*query);
+void *ast_dns_resolver_get_data(const struct ast_dns_query *query);
 /*!
  * \brief Set result information for a DNS query
  *
@@ -538,8 +538,8 @@ void \*ast_dns_resolver_get_data(const struct ast_dns_query \*query);
  * \param bogus Whether the result is bogus or not
  * \param canonical The canonical name
  */
-void ast_dns_resolver_set_result(struct ast_dns_query \*query, unsigned int nxdomain, unsigned int secure, unsigned int bogus,
- const char \*canonical);
+void ast_dns_resolver_set_result(struct ast_dns_query *query, unsigned int nxdomain, unsigned int secure, unsigned int bogus,
+ const char *canonical);
 /*!
  * \brief Add a DNS record to the result of a DNS query
  *
@@ -553,7 +553,7 @@ void ast_dns_resolver_set_result(struct ast_dns_query \*query, unsigned int nxdo
  * \retval 0 success
  * \retval -1 failure
  */
-int ast_dns_resolver_add_record(struct ast_dns_query \*query, int rr_type, int rr_class, int ttl, char \*data, size_t size);
+int ast_dns_resolver_add_record(struct ast_dns_query *query, int rr_type, int rr_class, int ttl, char *data, size_t size);
 /*!
  * \brief Mark a DNS query as having been completed
  *
@@ -561,7 +561,7 @@ int ast_dns_resolver_add_record(struct ast_dns_query \*query, int rr_type, int r
  *
  * \note Once this is invoked the resolver data on the query will be removed
  */
-void ast_dns_resolver_completed(const struct ast_dns_query \*query);
+void ast_dns_resolver_completed(const struct ast_dns_query *query);
 /*!
  * \brief Register a DNS resolver
  *
@@ -570,7 +570,7 @@ void ast_dns_resolver_completed(const struct ast_dns_query \*query);
  * \retval 0 success
  * \retval -1 failure
  */
-int ast_dns_resolver_register(const struct ast_core_dns_resolver \*resolver);
+int ast_dns_resolver_register(const struct ast_core_dns_resolver *resolver);
 /*!
  * \brief Unregister a DNS resolver
  *
@@ -579,7 +579,7 @@ int ast_dns_resolver_register(const struct ast_core_dns_resolver \*resolver);
  * \retval 0 success
  * \retval -1 failure
  */
-int ast_dns_resolver_unregister(const struct ast_core_dns_resolver \*resolver);
+int ast_dns_resolver_unregister(const struct ast_core_dns_resolver *resolver);
 
 ```
 
@@ -601,7 +601,7 @@ struct ast_dns_record {
  /*! \brief Time-to-live of the recor */
  int ttl;
  /*! \brief The raw DNS recor */
- char \*data;
+ char *data;
  /*! \brief The size of the raw DNS recor */
  size_t data_len;
  /*! \brief Linked list informatio */
@@ -612,7 +612,7 @@ struct ast_dns_srv_record {
  /*! \brief Generic DNS record informatio */
  struct ast_dns_record generic;
  /*! \brief The hostname in the SRV recor */
- const char \*host;
+ const char *host;
  /*! \brief The priority of the SRV recor */
  unsigned short priority;
  /*! \brief The weight of the SRV recor */
@@ -625,13 +625,13 @@ struct ast_dns_naptr_record {
  /*! \brief Generic DNS record informatio */
  struct ast_dns_record generic;
  /*! \brief The flags from the NAPTR recor */
- const char \*flags;
+ const char *flags;
  /*! \brief The service from the NAPTR recor */
- const char \*service;
+ const char *service;
  /*! \brief The regular expression from the NAPTR recor */
- const char \*regexp;
+ const char *regexp;
  /*! \brief The replacement from the NAPTR recor */
- const char \*replacement;
+ const char *replacement;
  /*! \brief The order for the NAPTR recor */
  unsigned short order;
  /*! \brief The preference of the NAPTR recor */
@@ -646,7 +646,7 @@ struct ast_dns_result {
  /*! \brief Whether the result is bogu */
  unsigned int bogus;
  /*! \brief The canonical nam */
- const char \*canonical;
+ const char *canonical;
  /*! \brief Records returne */
  AST_LIST_HEAD_NOLOCK(, ast_dns_record) records;
 };
@@ -655,24 +655,24 @@ struct ast_dns_query {
  /*! \brief Callback to invoke upon completio */
  ast_dns_resolve_callback callback;
  /*! \brief User-specific dat */
- void \*user_data;
+ void *user_data;
  /*! \brief Resolver-specific dat */
- void \*resolver_data;
+ void *resolver_data;
  /*! \brief Result of the DNS quer */
- struct ast_dns_result \*result;
+ struct ast_dns_result *result;
  /*! \brief Timer for recurring resolutio */
  int timer;
 };
 /*! \brief A set of DNS querie */
 struct ast_dns_query_set {
  /*! \brief DNS querie */
- AST_VECTOR(, struct ast_dns_query \*) queries;
+ AST_VECTOR(, struct ast_dns_query *) queries;
  /*! \brief The total number of completed querie */
  unsigned int queries_completed;
  /*! \brief Callback to invoke upon completio */
  ast_dns_query_set_callback callback;
  /*! \brief User-specific dat */
- void \*user_data;
+ void *user_data;
  /*! \brief Timer for recurring resolutio */
  int timer;
 };
@@ -691,9 +691,9 @@ This example blocks the calling thread until resolution has completed. Once comp
 #include <asterisk/dns.h>
 int test(void)
 {
- RAII_VAR(struct ast_dns_result \*, result, NULL, ast_dns_result_unref);
+ RAII_VAR(struct ast_dns_result *, result, NULL, ast_dns_result_unref);
  int res;
- struct ast_dns_record \*record;
+ struct ast_dns_record *record;
  res = ast_dns_resolve("www.asterisk.org", ns_c_in, ns_t_a, &result);
  if (res) {
  ast_verbose(1, "Synchronous resolution of 'asterisk.org' failed\n");
@@ -710,7 +710,7 @@ int test(void)
  return -1;
  }
  for (record = ast_dns_result_get_records(result); record; record = ast_dns_record_get_next(record)) {
- ast_verbose(1, "Got address: %s\n", inet_ntoa(\*(struct in_addr\*)ast_dns_record_get_data(record)));
+ ast_verbose(1, "Got address: %s\n", inet_ntoa(*(struct in_addr*)ast_dns_record_get_data(record)));
  }
  return 0;
 }
@@ -724,10 +724,10 @@ This example does not block the calling thread when resolving. A callback is inv
 
 ```bash title=" " linenums="1"
 #include <asterisk/dns.h>
-static void test_callback(const struct ast_dns_query \*query)
+static void test_callback(const struct ast_dns_query *query)
 {
- struct ast_dns_result \*result = ast_dns_query_get_result(query);
- struct ast_dns_record \*record;
+ struct ast_dns_result *result = ast_dns_query_get_result(query);
+ struct ast_dns_record *record;
  if (ast_dns_result_get_nxdomain(result)) {
  ast_verbose(1, "Specified domain name 'asterisk.org' does not exist\n");
  return;
@@ -739,7 +739,7 @@ static void test_callback(const struct ast_dns_query \*query)
  return;
  }
  for (record = ast_dns_result_get_records(result); record; record = ast_dns_record_get_next(record)) {
- ast_verbose(1, "Got address: %s\n", inet_ntoa(\*(struct in_addr\*)ast_dns_record_get_data(record)));
+ ast_verbose(1, "Got address: %s\n", inet_ntoa(*(struct in_addr*)ast_dns_record_get_data(record)));
  }
 }
 int test(void)
@@ -764,15 +764,15 @@ This example uses a query set to do two queries in an asynchronous manner. Each 
 ```bash title=" " linenums="1"
 #include <asterisk/dns.h>
 #include <asterisk/dns_query_set.h>
-static void test_callback(const struct ast_dns_query_query \*query_set)
+static void test_callback(const struct ast_dns_query_query *query_set)
 {
- struct ast_dns_result \*asterisk_result = ast_dns_query_get_result(ast_dns_query_set_get(query_set, 0));
- struct ast_dns_result \*digium_result = ast_dns_query_get_result(ast_dns_query_set_get(query_set, 1));
- struct ast_dns_record \*record;
+ struct ast_dns_result *asterisk_result = ast_dns_query_get_result(ast_dns_query_set_get(query_set, 0));
+ struct ast_dns_result *digium_result = ast_dns_query_get_result(ast_dns_query_set_get(query_set, 1));
+ struct ast_dns_record *record;
  if (!ast_dns_result_get_nxdomain(asterisk_result)) {
  ast_verbose(1, "'asterisk.org' resolution results:\n");
  for (record = ast_dns_result_get_records(asterisk_result); record; record = ast_dns_record_get_next(record)) {
- ast_verbose(1, "Got address: %s\n", inet_ntoa(\*(struct in_addr\*)ast_dns_record_get_data(record)));
+ ast_verbose(1, "Got address: %s\n", inet_ntoa(*(struct in_addr*)ast_dns_record_get_data(record)));
  }
  } else {
  ast_verbose(1, "'asterisk.org' domain does not exist\n");
@@ -780,7 +780,7 @@ static void test_callback(const struct ast_dns_query_query \*query_set)
  if (!ast_dns_result_get_nxdomain(digium_result)) {
  ast_verbose(1, "'digium.com' resolution results:\n");
  for (record = ast_dns_result_get_records(digium_result); record; record = ast_dns_record_get_next(record)) {
- ast_verbose(1, "Got address: %s\n", inet_ntoa(\*(struct in_addr\*)ast_dns_record_get_data(record)));
+ ast_verbose(1, "Got address: %s\n", inet_ntoa(*(struct in_addr*)ast_dns_record_get_data(record)));
  }
  } else {
  ast_verbose(1, "'digium.com' domain does not exist\n");
@@ -788,7 +788,7 @@ static void test_callback(const struct ast_dns_query_query \*query_set)
 }
 int test(void)
 {
- struct ast_dns_query_set \*query_set;
+ struct ast_dns_query_set *query_set;
  query_set = ast_dns_query_set_create():
  if (!query_set) {
  ast_verbose(1, "Could not create a query set for parallel resolution");
@@ -811,10 +811,10 @@ This example does a fall back from an AAAA record lookup to an A record lookup i
 
 ```bash title=" " linenums="1"
 #include <asterisk/dns.h>
-static void test_callback(const struct ast_dns_query \*query)
+static void test_callback(const struct ast_dns_query *query)
 {
- struct ast_dns_result \*result = ast_dns_query_get_result(query);
- struct ast_dns_record \*record = ast_dns_result_get_records(result);
+ struct ast_dns_result *result = ast_dns_query_get_result(query);
+ struct ast_dns_record *record = ast_dns_result_get_records(result);
  if (ast_dns_result_get_nxdomain(result) || !record) {
  ast_verbose(1, "Specified domain name 'asterisk.org' does not exist or has no records\n");
  if (ast_dns_get_rr_type(query) == ns_t_aaaa) {
@@ -858,40 +858,40 @@ This example does a NAPTR lookup followed by SRV followed by AAAA and then A. Th
 /* An alternative to this cascade approach would be using a query set to do NAPTR, SRV, AAAA, and A in parallel
  * with NAPTR and SRV adding additional queries afterwards
  */
-static void a_callback(const struct ast_dns_query \*query)
+static void a_callback(const struct ast_dns_query *query)
 {
- struct ast_dns_result \*result = ast_dns_query_get_result(query);
- struct ast_dns_record \*record = ast_dns_result_get_records(result);
+ struct ast_dns_result *result = ast_dns_query_get_result(query);
+ struct ast_dns_record *record = ast_dns_result_get_records(result);
  if (!record) {
  /* We have nowhere to g */
  return;
  }
  /* If we got here there is an A recor */
 }
-static void aaaa_callback(const struct ast_dns_query \*query)
+static void aaaa_callback(const struct ast_dns_query *query)
 {
- struct ast_dns_result \*result = ast_dns_query_get_result(query);
- struct ast_dns_record \*record = ast_dns_result_get_records(result);
+ struct ast_dns_result *result = ast_dns_query_get_result(query);
+ struct ast_dns_record *record = ast_dns_result_get_records(result);
  if (!record) {
  ast_dns_resolve_async(ast_dns_query_get_name(query), ns_c_in, ns_t_a, a_callback, NULL);
  return;
  }
  /* If we got here there is an AAAA recor */
 }
-static void srv_callback(const struct ast_dns_query \*query)
+static void srv_callback(const struct ast_dns_query *query)
 {
- struct ast_dns_result \*result = ast_dns_query_get_result(query);
- struct ast_dns_record \*record = ast_dns_result_get_records(result);
+ struct ast_dns_result *result = ast_dns_query_get_result(query);
+ struct ast_dns_record *record = ast_dns_result_get_records(result);
  if (record) {
  ast_dns_resolve_async(ast_dns_srv_get_host(record), ns_c_in, ns_t_aaaa, aaaa_callback, NULL);
  return;
  }
  ast_dns_resolve_async("asterisk.org", ns_c_in, ns_t_aaaa, aaaa_callback, NULL);
 }
-static void naptr_callback(const struct ast_dns_query \*query)
+static void naptr_callback(const struct ast_dns_query *query)
 {
- struct ast_dns_result \*result = ast_dns_query_get_result(query);
- struct ast_dns_record \*record;
+ struct ast_dns_result *result = ast_dns_query_get_result(query);
+ struct ast_dns_record *record;
  if (ast_dns_result_get_nxdomain(result)) {
  ast_verbose(1, "Specified domain name 'asterisk.org' does not exist\n");
  return;
@@ -926,10 +926,10 @@ The recurring example has the DNS core re-run the specified query according to t
 
 ```bash title=" " linenums="1"
 #include <asterisk/dns.h>
-static void test_callback(const struct ast_dns_query \*query)
+static void test_callback(const struct ast_dns_query *query)
 {
- struct ast_dns_result \*result = ast_dns_query_get_result(query);
- struct ast_dns_record \*record;
+ struct ast_dns_result *result = ast_dns_query_get_result(query);
+ struct ast_dns_record *record;
  if (ast_dns_result_get_nxdomain(result)) {
  ast_verbose(1, "Specified domain name 'asterisk.org' does not exist\n");
  return;
@@ -937,7 +937,7 @@ static void test_callback(const struct ast_dns_query \*query)
 
  /* Previous information should be stored and compared against new records, if different then take actio */
  for (record = ast_dns_result_get_records(result); record; record = ast_dns_record_get_next(record)) {
- ast_verbose(1, "Got address: %s\n", inet_ntoa(\*(struct in_addr\*)ast_dns_record_get_data(record)));
+ ast_verbose(1, "Got address: %s\n", inet_ntoa(*(struct in_addr*)ast_dns_record_get_data(record)));
  }
 }
 int test(void)

--- a/docs/Development/Roadmap/Asterisk-15-Projects/SDP-Work.md
+++ b/docs/Development/Roadmap/Asterisk-15-Projects/SDP-Work.md
@@ -129,7 +129,7 @@ struct ast_sdp_options;
  * Simple allocation for SDP options.
  * Initializes with sane defaults
  */
-struct ast_sdp_options \*ast_sdp_options_alloc(void);
+struct ast_sdp_options *ast_sdp_options_alloc(void);
 
 /*!
  * \brief Free SDP options.
@@ -139,7 +139,7 @@ struct ast_sdp_options \*ast_sdp_options_alloc(void);
  * that uses these options. Otherwise, freeing the SDP state
  * will free the SDP options it inherited.
  */
-void ast_sdp_options_free(struct ast_sdp_options \*options);
+void ast_sdp_options_free(struct ast_sdp_options *options);
 
 /*!
  * \brief General template for setting SDP options
@@ -147,7 +147,7 @@ void ast_sdp_options_free(struct ast_sdp_options \*options);
  * The types are going to differ for each individual option, hence
  * the "whatever" second parameter.
  */
-int ast_sdp_options_set_<whatever>(struct ast_sdp_options \*sdp_options, <whatever>);
+int ast_sdp_options_set_<whatever>(struct ast_sdp_options *sdp_options, <whatever>);
 
 /*!
  *\brief General template for retrieving SDP options
@@ -155,7 +155,7 @@ int ast_sdp_options_set_<whatever>(struct ast_sdp_options \*sdp_options, <whatev
  * The type being retrieved is going to be dependent on the option being retrieved,
  * thus the return type of "whatever" here.
  */
-<whatever> ast_sdp_options_get_<whatever>(struct ast_sdp_options \*sdp_options);
+<whatever> ast_sdp_options_get_<whatever>(struct ast_sdp_options *sdp_options);
 
 /*!
  * \brief Allocate a new SDP state
@@ -165,14 +165,14 @@ int ast_sdp_options_set_<whatever>(struct ast_sdp_options \*sdp_options, <whatev
  * Ownership of the SDP options is taken on by the SDP state.
  * A good strategy is to call this during session creation.
  */
-struct ast_sdp_state\* ast_sdp_state_alloc(struct ast_stream_topology \*streams, const struct ast_sdp_options \*options);
+struct ast_sdp_state* ast_sdp_state_alloc(struct ast_stream_topology *streams, const struct ast_sdp_options *options);
 
 /*!
  * \brief Free the SDP state.
  *
  * A good strategy is to call this during session destruction
  */
-void ast_sdp_state_free(struct ast_sdp_state \*sdp_state);
+void ast_sdp_state_free(struct ast_sdp_state *sdp_state);
 
 /*!
  * \brief Get the local SDP.
@@ -188,7 +188,7 @@ void ast_sdp_state_free(struct ast_sdp_state \*sdp_state);
  * message. The API user should not attempt to modify the SDP. SDP modification should only be done through
  * the API.
  */
-const void \*ast_sdp_state_get_local(const struct ast_sdp_state \*sdp_state);
+const void *ast_sdp_state_get_local(const struct ast_sdp_state *sdp_state);
 
 /*!
  * \brief Set the remote SDP.
@@ -201,7 +201,7 @@ const void \*ast_sdp_state_get_local(const struct ast_sdp_state \*sdp_state);
  * This function will allocate RTP instances if RTP instances have not already
  * been allocated for the streams.
  */
-int ast_sdp_state_set_remote(struct ast_sdp_state \*sdp, void \*remote);
+int ast_sdp_state_set_remote(struct ast_sdp_state *sdp, void *remote);
 
 /*!
  * \brief Reset the SDP state and stream capabilities as if the SDP state had just been allocated.
@@ -210,20 +210,20 @@ int ast_sdp_state_set_remote(struct ast_sdp_state \*sdp, void \*remote);
  * and needs to re-advertise its initial capabilities instead of the previously-negotiated
  * joint capabilities.
  */
-int ast_sdp_state_reset(struct ast_sdp_state \*sdp);
+int ast_sdp_state_reset(struct ast_sdp_state *sdp);
 
 /*!
  * \brief Get the associated RTP instance for a particular stream on the SDP state.
  *
  * Stream numbers correspond to the streams in the topology of the associated channel
  */
-struct ast_rtp_instance \*ast_sdp_state_get_rtp_instance(const struct ast_sdp_state \*sdp_state, int stream_index);
+struct ast_rtp_instance *ast_sdp_state_get_rtp_instance(const struct ast_sdp_state *sdp_state, int stream_index);
 
 /*!
  * \brief Get the joint negotiated streams based on local and remote capabilities.
  * If this is called prior to receiving a remote SDP, then this will just mirror the local configured endpoint capabilities.
  */
-struct ast_stream_topology \*ast_sdp_state_get_joint_topology(const struct ast_sdp_state \*sdp_state);
+struct ast_stream_topology *ast_sdp_state_get_joint_topology(const struct ast_sdp_state *sdp_state);
 
 /*!
  * \brief Update remote and local stream capabilities
@@ -235,14 +235,14 @@ struct ast_stream_topology \*ast_sdp_state_get_joint_topology(const struct ast_s
  * Retrieval of the local SDP after calling either of these functions will result in the appropriate
  * joint stream capabilities being represented.
  */
-int ast_sdp_state_update_local_topology(struct ast_sdp_state \*state, struct ast_stream_topology \*new_topology);
-int ast_sdp_state_update_remote_topology(struct ast_sdp_state \*state, struct ast_stream_topology \*new_topology);
+int ast_sdp_state_update_local_topology(struct ast_sdp_state *state, struct ast_stream_topology *new_topology);
+int ast_sdp_state_update_remote_topology(struct ast_sdp_state *state, struct ast_stream_topology *new_topology);
 
 /*
  * Override the default connection address for SDP.
  * This is useful for NAT operations and for direct media.
  */
-int ast_sdp_state_set_connection_address(struct ast_sdp_state \*state, struct ast_sockaddr \*addr);
+int ast_sdp_state_set_connection_address(struct ast_sdp_state *state, struct ast_sockaddr *addr);
 
 ```
 
@@ -288,12 +288,12 @@ The callback would look something like the following:
  * This will be called each time a new ICE candidate is discovered on an RTP instance.
  * The opaque pointer is the same data that was passed in when registering the callback.
  */
-typedef int (\*new_candidate_fn)(struct ast_rtp_instance \*rtp, struct ast_rtp_engine_ice_candidate \*candidate, void \*data);
+typedef int (*new_candidate_fn)(struct ast_rtp_instance *rtp, struct ast_rtp_engine_ice_candidate *candidate, void *data);
 
 /*
  * Indicate interest in being told of new ICE candidates.
  * 
-int ast_rtp_instance_register_ice_new_candidate_cb(struct ast_rtp_instance \*rtp, new_candidate_fn cb, void \*data);
+int ast_rtp_instance_register_ice_new_candidate_cb(struct ast_rtp_instance *rtp, new_candidate_fn cb, void *data);
 
 ```
 
@@ -309,10 +309,10 @@ Code samples
 Here is a hypothetical allocation of an `ast_sdp_state`.
 
 ```
-int init_session(struct my_channel_driver_session \*session)
+int init_session(struct my_channel_driver_session *session)
 {
- struct ast_sdp_options \*sdp_options;
- struct ast_sdp_state \*sdp_state;
+ struct ast_sdp_options *sdp_options;
+ struct ast_sdp_state *sdp_state;
 
  sdp_options = ast_sdp_options_alloc();
  if (!sdp_options) {
@@ -355,9 +355,9 @@ In this example, we enable several SDP options and then use those to allocate th
 Now let's make a call.
 
 ```
-int make_a_call(struct my_channel_driver_session \*session, char \*dest)
+int make_a_call(struct my_channel_driver_session *session, char *dest)
 {
- struct my_channel_driver_message \*message;
+ struct my_channel_driver_message *message;
 
  message = make_call_message(dest);
 
@@ -373,14 +373,14 @@ When it comes time to make a call, all we have to do is request our local SDP, t
 Now what about receiving an incoming call.
 
 ```
-int incoming_call(struct my_channel_driver_session \*session, struct my_channel_driver_message \*message)
+int incoming_call(struct my_channel_driver_session *session, struct my_channel_driver_message *message)
 { 
- struct my_channel_driver_message \*response;
+ struct my_channel_driver_message *response;
 
  if (message->sdp) {
- struct ast_stream_topology \*joint_topology;
- struct ast_stream_topology \*old_channel_topology;
- struct ast_stream_topology \*channel_topology;
+ struct ast_stream_topology *joint_topology;
+ struct ast_stream_topology *old_channel_topology;
+ struct ast_stream_topology *channel_topology;
  ast_sdp_state_set_remote(session->sdp_state, message->sdp);
  joint_topology = ast_stream_topology_copy(ast_sdp_state_get_joint_topology(session->sdp_state));
 
@@ -408,10 +408,10 @@ This is very similar to what we did when creating an outgoing call. The interest
 Now let's look at a hypothetical switchover to direct media.
 
 ```
-int direct_media_enabled(struct my_channel_driver_session \*session, struct ast_stream_topology \*peer_topology, struct ast_sockaddr \*peer_addr)
+int direct_media_enabled(struct my_channel_driver_session *session, struct ast_stream_topology *peer_topology, struct ast_sockaddr *peer_addr)
 {
- struct my_channel_driver_message \*message;
- struct ast_format_cap \*joint_topology;
+ struct my_channel_driver_message *message;
+ struct ast_format_cap *joint_topology;
 
  ast_sdp_state_update_local_topology(session->sdp_state, peer_topology);
  joint_topology = ast_sdp_state_get_joint_topology(session->sdp_state);

--- a/docs/Development/Roadmap/Asterisk-15-Projects/Stream-Support.md
+++ b/docs/Development/Roadmap/Asterisk-15-Projects/Stream-Support.md
@@ -167,14 +167,14 @@ enum ast_stream_state {
  *
  * \note The stream will default to an inactive state until changed.
  */
-struct ast_stream \*ast_stream_create(const char \*name, enum ast_media_type type);
+struct ast_stream *ast_stream_create(const char *name, enum ast_media_type type);
 
 /*!
  * \brief Destroy a media stream representation
  *
  * \param stream The media stream
  */
-void ast_stream_destroy(struct ast_stream \*stream);
+void ast_stream_destroy(struct ast_stream *stream);
 
 /*!
  * \brief Get the name of a stream
@@ -183,7 +183,7 @@ void ast_stream_destroy(struct ast_stream \*stream);
  *
  * \return The name of the stream
  */
-const char \*ast_stream_get_name(const struct ast_stream \*stream);
+const char *ast_stream_get_name(const struct ast_stream *stream);
 
 /*!
  * \brief Get the media type of a stream
@@ -192,7 +192,7 @@ const char \*ast_stream_get_name(const struct ast_stream \*stream);
  *
  * \return The media type of the stream
  */
-enum ast_media_type ast_stream_get_type(const struct ast_stream \*stream);
+enum ast_media_type ast_stream_get_type(const struct ast_stream *stream);
 
 /*!
  * \brief Change the media type of a stream
@@ -200,7 +200,7 @@ enum ast_media_type ast_stream_get_type(const struct ast_stream \*stream);
  * \param stream The media stream
  * \param type The new media type
  */
-void ast_stream_set_type(struct ast_stream \*stream, enum ast_media_type type);
+void ast_stream_set_type(struct ast_stream *stream, enum ast_media_type type);
 /*!
  * \brief Get the current negotiated formats of a stream
  *
@@ -210,7 +210,7 @@ void ast_stream_set_type(struct ast_stream \*stream, enum ast_media_type type);
  *
  * \note The reference count is not increased
  */
-struct ast_format_cap \*ast_stream_get_formats(const struct ast_stream \*stream);
+struct ast_format_cap *ast_stream_get_formats(const struct ast_stream *stream);
 
 /*!
  * \brief Set the current negotiated formats of a stream
@@ -218,7 +218,7 @@ struct ast_format_cap \*ast_stream_get_formats(const struct ast_stream \*stream)
  * \param stream The media stream
  * \param caps The current negotiated formats
  */
-void ast_stream_set_formats(struct ast_stream \*stream, ast_format_cap \*caps);
+void ast_stream_set_formats(struct ast_stream *stream, ast_format_cap *caps);
 
 /*!
  * \brief Get the current state of a stream
@@ -227,7 +227,7 @@ void ast_stream_set_formats(struct ast_stream \*stream, ast_format_cap \*caps);
  *
  * \return The state of the stream
  */
-enum ast_stream_state ast_stream_get_state(const struct ast_stream \*stream);
+enum ast_stream_state ast_stream_get_state(const struct ast_stream *stream);
 
 /*!
  * \brief Set the state of a stream
@@ -237,7 +237,7 @@ enum ast_stream_state ast_stream_get_state(const struct ast_stream \*stream);
  *
  * \note Used by stream creator to update internal state
  */
-void ast_stream_set_state(struct ast_stream \*stream, enum ast_stream_state state);
+void ast_stream_set_state(struct ast_stream *stream, enum ast_stream_state state);
 
 /*!
  * \brief Get the number of the stream
@@ -246,7 +246,7 @@ void ast_stream_set_state(struct ast_stream \*stream, enum ast_stream_state stat
  *
  * \return The number of the stream
  */
-unsigned int ast_stream_get_num(const struct ast_stream \*stream);
+unsigned int ast_stream_get_num(const struct ast_stream *stream);
 
 /*!
  * \brief Create a stream topology
@@ -254,7 +254,7 @@ unsigned int ast_stream_get_num(const struct ast_stream \*stream);
  * \retval non-NULL success
  * \retval NULL failure
  */
-struct ast_stream_topology \*ast_stream_topology_new(void);
+struct ast_stream_topology *ast_stream_topology_new(void);
 
 /*!
  * \brief Add a stream to the topology
@@ -265,7 +265,7 @@ struct ast_stream_topology \*ast_stream_topology_new(void);
  * \retval 0 success
  * \retval -1 failure
  */
-int ast_stream_topology_add(struct ast_stream_topology \*topology, struct ast_stream \*stream);
+int ast_stream_topology_add(struct ast_stream_topology *topology, struct ast_stream *stream);
 
 /*!
  * \brief Get the number of streams in a topology
@@ -274,7 +274,7 @@ int ast_stream_topology_add(struct ast_stream_topology \*topology, struct ast_st
  *
  * \return the number of streams
  */
-size_t ast_stream_topology_num(const struct ast_stream_topology \*topology);
+size_t ast_stream_topology_num(const struct ast_stream_topology *topology);
 
 /*!
  * \brief Get a specific stream from the topology
@@ -284,7 +284,7 @@ size_t ast_stream_topology_num(const struct ast_stream_topology \*topology);
  * \retval non-NULL success
  * \retval NULL failure
  */
-struct ast_stream \*ast_stream_topology_get(const struct ast_stream_topology \*topology, unsigned int stream_num);
+struct ast_stream *ast_stream_topology_get(const struct ast_stream_topology *topology, unsigned int stream_num);
 
 /*!
  * \brief Copy an existing stream topology
@@ -294,7 +294,7 @@ struct ast_stream \*ast_stream_topology_get(const struct ast_stream_topology \*t
  * \retval non-NULL success
  * \retval NULL failure
  */
-struct ast_stream_topology \*ast_stream_topology_copy(const struct ast_stream_topology \*topology);
+struct ast_stream_topology *ast_stream_topology_copy(const struct ast_stream_topology *topology);
 
 /*!
  * \brief Set a specific numbered stream in a topology
@@ -308,7 +308,7 @@ struct ast_stream_topology \*ast_stream_topology_copy(const struct ast_stream_to
  *
  * \note If an existing stream exists it will be destroyed
  */
-int ast_stream_topology_set(struct ast_stream_topology \*topology, unsigned int num, struct ast_stream \*stream);
+int ast_stream_topology_set(struct ast_stream_topology *topology, unsigned int num, struct ast_stream *stream);
 
 /*!
  * \brief A helper function that given a set of formats creates a topology with the required streams to satisfy them
@@ -322,7 +322,7 @@ int ast_stream_topology_set(struct ast_stream_topology \*topology, unsigned int 
  *
  * \note Each stream will be to sendrecv state
  */
-struct ast_stream_topology \*ast_stream_topology_make(struct ast_format_cap \*caps);
+struct ast_stream_topology *ast_stream_topology_make(struct ast_format_cap *caps);
 
 /*!
  * \brief Destroy a stream topology
@@ -331,7 +331,7 @@ struct ast_stream_topology \*ast_stream_topology_make(struct ast_format_cap \*ca
  *
  * \note All streams contained within the topology will be destroyed
  */
-void ast_stream_topology_destroy(struct ast_stream_topology \*topology);
+void ast_stream_topology_destroy(struct ast_stream_topology *topology);
 
 ```
 
@@ -363,7 +363,7 @@ struct ast_stream {
  /*!
  * \brief Current formats negotiated on the stream
  */
- struct ast_format_cap \*formats;
+ struct ast_format_cap *formats;
  /*!
  * \brief The current state of the stream
  */
@@ -378,7 +378,7 @@ struct ast_stream_topology {
  /*!
  * \brief A vector of all the streams in this topology
  */
- AST_VECTOR(, struct ast_stream \*) streams;
+ AST_VECTOR(, struct ast_stream *) streams;
 };
 
 ```
@@ -400,7 +400,7 @@ struct ast_channel_tech {
  /*!
  * \brief Callback invoked to write a frame to a specific stream
  */
- int (\* const write_stream)(struct ast_channel \*chan, unsigned int stream_num, struct ast_frame \*frame);
+ int (* const write_stream)(struct ast_channel *chan, unsigned int stream_num, struct ast_frame *frame);
 };
 
 /*!
@@ -415,7 +415,7 @@ struct ast_channel_tech {
  * \retval 0 success
  * \retval -1 failure
  */
-int ast_write_stream(struct ast_channel \*chan, unsigned int stream_num, struct ast_frame \*frame);
+int ast_write_stream(struct ast_channel *chan, unsigned int stream_num, struct ast_frame *frame);
 
 /*!
  * \brief Read a frame from all streams
@@ -428,7 +428,7 @@ int ast_write_stream(struct ast_channel \*chan, unsigned int stream_num, struct 
  * \retval non-NULL success
  * \retval NULL failure
  */
-struct ast_frame \*ast_read_streams(struct ast_channel \*chan, unsigned int \*stream_num);
+struct ast_frame *ast_read_streams(struct ast_channel *chan, unsigned int *stream_num);
 
 /*!
  * \brief Retrieve the topology of streams on a channel
@@ -440,7 +440,7 @@ struct ast_frame \*ast_read_streams(struct ast_channel \*chan, unsigned int \*st
  * \retval non-NULL success
  * \retval NULL failure
  */
-struct ast_stream_topology \*ast_channel_get_stream_topology(const struct ast_channel \*chan);
+struct ast_stream_topology *ast_channel_get_stream_topology(const struct ast_channel *chan);
 
 /*!
  * \brief Request that the stream topology of a channel change
@@ -461,7 +461,7 @@ struct ast_stream_topology \*ast_channel_get_stream_topology(const struct ast_ch
  * \note This interface is provided for applications and resources to request that the topology change.
  * It is not for use by the channel driver itself.
  */
-int ast_channel_stream_topology_request_change(struct ast_channel \*chan, struct ast_stream_topology \*topology);
+int ast_channel_stream_topology_request_change(struct ast_channel *chan, struct ast_stream_topology *topology);
 
 /*!
  * \brief Provide notice to a channel that the stream topology has changed
@@ -475,7 +475,7 @@ int ast_channel_stream_topology_request_change(struct ast_channel \*chan, struct
  * \note This interface is provided for applications and resources to accept a topology change.
  * It is not for use by the channel driver itself.
  */
-int ast_channel_stream_topology_changed(struct ast_channel \*chan, struct ast_stream_topology \*topology);
+int ast_channel_stream_topology_changed(struct ast_channel *chan, struct ast_stream_topology *topology);
 
 ```
 
@@ -529,7 +529,7 @@ Creating streams on a channel
 -----------------------------
 
 ```
- struct ast_stream \*audio_stream, \*video_stream;
+ struct ast_stream *audio_stream, *video_stream;
 
  audio_stream = ast_stream_create("audio", AST_MEDIA_TYPE_AUDIO);
  video_stream = ast_stream_create("video", AST_MEDIA_TYPE_VIDEO);
@@ -548,13 +548,13 @@ Iterating
 
 ```
  int i;
- struct ast_stream_topology \*topology;
+ struct ast_stream_topology *topology;
 
  ast_channel_lock(chan);
 
  topology = ast_channel_get_stream_topology(chan);
  for (i = 0; i < ast_stream_topology_num(topology); i++) {
- struct ast_stream \*stream;
+ struct ast_stream *stream;
 
  stream = ast_stream_topology_get(topology, i);
  }
@@ -569,8 +569,8 @@ Requesting a change to the stream topology
 ------------------------------------------
 
 ```
- struct ast_stream_topology \*modified;
- struct ast_stream \*first;
+ struct ast_stream_topology *modified;
+ struct ast_stream *first;
 
  ast_channel_lock(chan);
 
@@ -589,7 +589,7 @@ Handling a request to change the stream topology
 ------------------------------------------------
 
 ```
- struct ast_frame \*frame;
+ struct ast_frame *frame;
  unsigned int stream_num;
 
  frame = ast_read_streams(chan, &stream_num);

--- a/docs/Development/Roadmap/Asterisk-16-Projects/WebRTC-User-Experience-Improvements.md
+++ b/docs/Development/Roadmap/Asterisk-16-Projects/WebRTC-User-Experience-Improvements.md
@@ -42,7 +42,7 @@ A data buffer acts as a ring buffer of data. It is given a fixed number of data 
  *
  * \param The data payload
  */
-typedef void (\*ast_data_buffer_free_callback)(void \*data);
+typedef void (*ast_data_buffer_free_callback)(void *data);
 
 /*!
  * \brief Data buffer containing fixed number of data payloads
@@ -63,7 +63,7 @@ struct ast_data_buffer {
  * \retval non-NULL success
  * \retval NULL failure
  */
-struct ast_data_buffer \*ast_data_buffer_alloc(ast_data_buffer_free_callback free_fn, size_t size);
+struct ast_data_buffer *ast_data_buffer_alloc(ast_data_buffer_free_callback free_fn, size_t size);
 
 /*!
  * \brief Resize a data buffer
@@ -73,7 +73,7 @@ struct ast_data_buffer \*ast_data_buffer_alloc(ast_data_buffer_free_callback fre
  *
  * \note If the data buffer is shrunk any old data payloads will be freed using the configured callback
  */
-void ast_data_buffer_resize(struct ast_data_buffer \*buffer, size_t size);
+void ast_data_buffer_resize(struct ast_data_buffer *buffer, size_t size);
 
 /*!
  * \brief Place a data payload at a position in the data buffer
@@ -87,7 +87,7 @@ void ast_data_buffer_resize(struct ast_data_buffer \*buffer, size_t size);
  *
  * \note It is up to the consumer of this API to ensure proper memory management of data payloads
  */
-int ast_data_buffer_put(struct ast_data_buffer \*buffer, int pos, void \*payload);
+int ast_data_buffer_put(struct ast_data_buffer *buffer, int pos, void *payload);
 
 /*!
  * \brief Retrieve a data payload from the data buffer
@@ -100,14 +100,14 @@ int ast_data_buffer_put(struct ast_data_buffer \*buffer, int pos, void \*payload
  *
  * \note This does not remove the data payload from the data buffer. It will be removed when it is displaced.
  */
-void \*ast_data_buffer_get(const struct ast_data_buffer \*buffer, int pos);
+void *ast_data_buffer_get(const struct ast_data_buffer *buffer, int pos);
 
 /*!
  * \brief Free a data buffer (and all held data payloads)
  *
  * \param buffer The data buffer
  */
-void ast_data_buffer_free(struct ast_data_buffer \*buffer);
+void ast_data_buffer_free(struct ast_data_buffer *buffer);
 
 ```
 
@@ -141,7 +141,7 @@ The RTP engine API also needs to have two API calls added:
  * \param rtp The RTP instance
  * \return The SSRC value
  */
-unsigned int ast_rtp_instance_get_rtx_ssrc(struct ast_rtp_instance \*rtp);
+unsigned int ast_rtp_instance_get_rtx_ssrc(struct ast_rtp_instance *rtp);
 
 /*!
  * \brief Set the remote RTP packet retransmission (RTX) SSRC for an RTP instance
@@ -149,7 +149,7 @@ unsigned int ast_rtp_instance_get_rtx_ssrc(struct ast_rtp_instance \*rtp);
  * \param rtp The RTP instance
  * \param ssrc The remote RTX SSRC
  */
-void ast_rtp_instance_set_remote_rtx_ssrc(struct ast_rtp_instance \*rtp, unsigned int ssrc);
+void ast_rtp_instance_set_remote_rtx_ssrc(struct ast_rtp_instance *rtp, unsigned int ssrc);
 
 ```
 

--- a/docs/Development/Roadmap/Asterisk-18-Projects/STIR-and-SHAKEN.md
+++ b/docs/Development/Roadmap/Asterisk-18-Projects/STIR-and-SHAKEN.md
@@ -99,21 +99,21 @@ struct ast_stir_shaken_payload {
  /* This is actually a JWT (JSON Web Token) so this may need to change, but for this page it'll d */
 
  /*! The JWT heade */
- struct ast_json \*header;
+ struct ast_json *header;
  /*! The JWT payloa */
- struct ast_json \*payload;
+ struct ast_json *payload;
  /*! Signature for the payloa */
- char \*signature;
+ char *signature;
  /*! The algorithm use */
- char \*algorithm;
+ char *algorithm;
  /*! The URL to the public key for the certificat */
- char \*public_key_url;
+ char *public_key_url;
 };
 
 /*!
  * \brief Free a STIR/SHAKEN payload
  */
-void ast_stir_shaken_payload_free(struct ast_stir_shaken_payload \*payload);
+void ast_stir_shaken_payload_free(struct ast_stir_shaken_payload *payload);
 
 ```
 
@@ -129,7 +129,7 @@ The module will expose a single API call that can be used to sign a payload.
  *
  * \note This function will automatically add the "attest", "iat", and "origid" fields.
  */
-struct ast_stir_shaken_payload \*ast_stir_shaken_sign(struct ast_json \*json);
+struct ast_stir_shaken_payload *ast_stir_shaken_sign(struct ast_json *json);
 
 ```
 
@@ -150,7 +150,7 @@ The module will expose a single API call that can be used to verify a payload.
 /*!
  * \brief Verify a JSON STIR/SHAKEN payload
  */
-struct ast_stir_shaken_payload \*ast_stir_shaken_verify(const char \*header, const char \*payload, const char \*signature, const char \*algorithm, const char \*public_key_url);
+struct ast_stir_shaken_payload *ast_stir_shaken_verify(const char *header, const char *payload, const char *signature, const char *algorithm, const char *public_key_url);
 
 ```
 
@@ -181,7 +181,7 @@ enum ast_stir_shaken_verification_result {
 /*!
  * \brief Add a STIR/SHAKEN verification result to a channel
  */
-int ast_stir_shaken_add_verification(struct ast_channel \*chan, const char \*identity, const char \*attestation, enum ast_stir_shaken_verification_result result);
+int ast_stir_shaken_add_verification(struct ast_channel *chan, const char *identity, const char *attestation, enum ast_stir_shaken_verification_result result);
 
 ```
 

--- a/docs/Fundamentals/Asterisk-Architecture/Types-of-Asterisk-Modules/index.md
+++ b/docs/Fundamentals/Asterisk-Architecture/Types-of-Asterisk-Modules/index.md
@@ -7,7 +7,7 @@ Use the [CLI](/Operation/Asterisk-Command-Line-Interface) command `module show` 
 
 Example:
 ```
-mypbx\*CLI> module show 
+mypbx*CLI> module show 
 Module Description Use Count Status Support Level
 app_adsiprog.so Asterisk ADSI Programming Application 0 Running extended
 app_agent_pool.so Call center agent pool applications 0 Running core

--- a/docs/Fundamentals/Asterisk-Configuration/Asterisk-Configuration-Files/Adding-to-an-existing-section.md
+++ b/docs/Fundamentals/Asterisk-Configuration/Asterisk-Configuration-Files/Adding-to-an-existing-section.md
@@ -76,7 +76,7 @@ allow=ulaw
 type=aor
 default_expiration=3600
 
-[101](+default_.\*=36[0-9][0-9])
+[101](+default_.*=36[0-9][0-9])
 default_expiration=1200
 
 [101](+type=endpoint)
@@ -99,7 +99,7 @@ allow=ulaw
 type=aor
 default_expiration=3600
 
-[101](+type=aor&default_.\*=36[0-9][0-9])
+[101](+type=aor&default_.*=36[0-9][0-9])
 default_expiration=1200
 
 [101](+type=endpoint)
@@ -124,7 +124,7 @@ default_expiration=3600
 
 [101](aor_template)
 
-[101](+TEMPLATES=restrict&default_.\*=36[0-9][0-9])
+[101](+TEMPLATES=restrict&default_.*=36[0-9][0-9])
 default_expiration=1200
 
 [101](+type=endpoint)

--- a/docs/Fundamentals/Asterisk-Internal-Database/index.md
+++ b/docs/Fundamentals/Asterisk-Internal-Database/index.md
@@ -29,7 +29,7 @@ Database commands on the CLI
 Sub-commands under the command "database" allow a variety of functions to be performed on or with the database.
 
 ```
-\*CLI> core show help database
+*CLI> core show help database
 database del -- Removes database key/value
 database deltree -- Removes database keytree/values
 database get -- Gets database value

--- a/docs/Fundamentals/Key-Concepts/States-and-Presence/Extension-State-and-Hints.md
+++ b/docs/Fundamentals/Key-Concepts/States-and-Presence/Extension-State-and-Hints.md
@@ -52,7 +52,7 @@ The [Querying and Manipulating State](/Fundamentals/Key-Concepts/States-and-Pres
 For a quick CLI example, once you have defined some hints, you can easily check from the CLI to verify they get loaded correctly.
 
 ```
-\*CLI> core show hints
+*CLI> core show hints
  -= Registered Asterisk Dial Plan Hints =-
  6003@internal : SIP/Charlie&DAHDI/3 State:Unavailable Watchers 0
  6002@internal : SIP/Bob State:Unavailable Watchers 0

--- a/docs/Fundamentals/Key-Concepts/States-and-Presence/Presence-State.md
+++ b/docs/Fundamentals/Key-Concepts/States-and-Presence/Presence-State.md
@@ -106,7 +106,7 @@ When a SIP device is subscribed to a hint you have configured in Asterisk and th
 Click here to see the NOTIFY example
 
 ```
-myserver\*CLI> presencestate change CustomPresence:6002 UNAVAILABLE
+myserver*CLI> presencestate change CustomPresence:6002 UNAVAILABLE
 Changing 6002 to UNAVAILABLE
 set_destination: Parsing <sip:6002@10.24.18.138:5060;ob> for address/port to send to
 set_destination: set destination to 10.24.18.138:5060

--- a/docs/Fundamentals/Key-Concepts/States-and-Presence/Querying-and-Manipulating-State.md
+++ b/docs/Fundamentals/Key-Concepts/States-and-Presence/Querying-and-Manipulating-State.md
@@ -31,7 +31,7 @@ The **[EXTENSION_STATE](/Latest_API/API_Documentation/Dialplan_Functions/EXTENSI
 The CLI command **core show hints** will show extension state for all defined hints, as well as display a truncated list of the mapped Device State or Presence State identifiers.
 
 ```
-myserver\*CLI> core show hints
+myserver*CLI> core show hints
  -= Registered Asterisk Dial Plan Hints =-
  6002@from-internal : SIP/6002 State:Unavailable Watchers 0
  7777@from-internal : SIP/6003,CustomPrese State:Unavailable Watchers 0
@@ -48,7 +48,7 @@ Added in Asterisk 11, the **[PRESENCE_STATE](/Latest_API/API_Documentation/Dialp
 The **presencestate** CLI command will list or modify any currently defined Presence State resources provided by the CustomPresence provider.
 
 ```
-myserver\*CLI> core show help presencestate 
+myserver*CLI> core show help presencestate 
 presencestate change -- Change a custom presence state
 presencestate list -- List currently know custom presence states
 

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/PJSIP-pjproject.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/PJSIP-pjproject.md
@@ -150,10 +150,10 @@ pjlib/include/pj/config_site.h
 #endif
 
 #define PJ_ENABLE_EXTRA_CHECK 1
-#define PJSIP_MAX_TSX_COUNT ((64\*1024)-1)
-#define PJSIP_MAX_DIALOG_COUNT ((64\*1024)-1)
-#define PJSIP_UDP_SO_SNDBUF_SIZE (512\*1024)
-#define PJSIP_UDP_SO_RCVBUF_SIZE (512\*1024)
+#define PJSIP_MAX_TSX_COUNT ((64*1024)-1)
+#define PJSIP_MAX_DIALOG_COUNT ((64*1024)-1)
+#define PJSIP_UDP_SO_SNDBUF_SIZE (512*1024)
+#define PJSIP_UDP_SO_RCVBUF_SIZE (512*1024)
 #define PJ_DEBUG 0
 #define PJSIP_SAFE_MODULE 0
 #define PJ_HAS_STRICMP_ALNUM 0
@@ -179,12 +179,12 @@ pjlib/include/pj/config_site.h
 
 /* Defaults too low for WebRT */
 #define PJ_ICE_MAX_CAND 32
-#define PJ_ICE_MAX_CHECKS (PJ_ICE_MAX_CAND \* PJ_ICE_MAX_CAND)
+#define PJ_ICE_MAX_CHECKS (PJ_ICE_MAX_CAND * PJ_ICE_MAX_CAND)
 
 /* Increase limits to allow more format */
 #define PJMEDIA_MAX_SDP_FMT 64
 #define PJMEDIA_MAX_SDP_BANDW 4
-#define PJMEDIA_MAX_SDP_ATTR (PJMEDIA_MAX_SDP_FMT\*2 + 4)
+#define PJMEDIA_MAX_SDP_ATTR (PJMEDIA_MAX_SDP_FMT*2 + 4)
 #define PJMEDIA_MAX_SDP_MEDIA 16
 
 /*
@@ -412,7 +412,7 @@ If you don't have an "uninstall" make target, you may need to fetch and merge th
 Alternatively, the following should also remove all previously installed static libraries:
 
 ```bash title=" " linenums="1"
-# rm -f /usr/lib/libpj\*.a /usr/lib/libmilenage\*.a /usr/lib/pkgconfig/libpjproject.pc
+# rm -f /usr/lib/libpj*.a /usr/lib/libmilenage*.a /usr/lib/pkgconfig/libpjproject.pc
 
 ```
 

--- a/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Code-Review/Coding-Guidelines.md
+++ b/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Code-Review/Coding-Guidelines.md
@@ -77,7 +77,7 @@ Keep the number of header files small by not including them unnecessarily. Don't
 * Functions and variables that are not intended to be used outside the module must be declared static. If you are compiling on a Linux platform that has the 'dwarves' package available, you can use the 'pglobal' tool from that package to check for unintended global variables or functions being exposed in your object files. Usage is very simple:
 
 ```
-$ pglobal \-vf <path to .o file>
+$ pglobal -vf <path to .o file>
 ```
 * When reading integer numeric input with scanf (or variants), do _NOT_ use '%i' unless you specifically want to allow non-base-10 input; '%d' is always a better choice, since it will not silently turn numbers with leading zeros into base-8.
 
@@ -90,7 +90,7 @@ On many platforms, structure fields (in structures that are not marked 'packed')
 ```
 struct foo {
  int bar;
- void \*xyz;
+ void *xyz;
 }
 
 ```
@@ -98,7 +98,7 @@ struct foo {
 On nearly every 64-bit platform, this will result in 4 bytes of dead space between 'bar' and 'xyz', because pointers on 64-bit platforms must be aligned on 8-byte boundaries. Once you have your code written and tested, it may be worthwhile to review your structure definitions to look for problems of this nature. If you are on a Linux platform with the 'dwarves' package available, the 'pahole' tool from that package can be used to both check for padding issues of this type and also propose reorganized structure definitions to eliminate it. Usage is quite simple; for a structure named 'foo', the command would look something like this:
 
 ```
-$ pahole \--reorganize \--show_reorg_steps \-C foo <path to module>
+$ pahole --reorganize --show_reorg_steps -C foo <path to module>
 ```
 The 'pahole' tool has many other modes available, including some that will list all the structures declared in the module and the amount of padding in each one that could possibly be recovered.
 
@@ -164,7 +164,7 @@ Following are examples of how code should be formatted.
 ### Functions:
 
 ```
-int foo(int a, char \*s)
+int foo(int a, char *s)
 {
  return 0;
 }
@@ -367,11 +367,11 @@ use them when possible.
 When allocating/zeroing memory for a structure, use code like this:
 
 ```
-struct foo \*tmp;
+struct foo *tmp;
 
 ...
 
-tmp = ast_calloc(1, sizeof(\*tmp));
+tmp = ast_calloc(1, sizeof(*tmp));
 
 ```
 
@@ -406,11 +406,11 @@ Furthermore, it is unnecessary to have code that malloc/calloc's for the length 
 
 New CLI commands should be named using the module's name, followed by a verb and then any parameters that the command needs. For example:
 ```
-\*CLI> iax2 show peer <peername>
+*CLI> iax2 show peer <peername>
 ```
 not
 ```
-\*CLI> show iax2 peer <peername>
+*CLI> show iax2 peer <peername>
 ```
 ## New dialplan applications/functions
 

--- a/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Git-Usage.md
+++ b/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Git-Usage.md
@@ -100,10 +100,10 @@ Useful Commands and Tips
 
 	$ git log --graph --decorate --no-merges -E --grep="^(realtime: Add database scripts for|ChangeLog:|Release summaries:|[.])" \
 	$ --invert-grep --pretty=format:'%Cred %h %C(yellow) %d %Creset %<(60,trunc) %s %Cgreen(%cr)' 13.8..13.9
-	\* d27ee3b res_sorcery_astdb: Fix creation of retrieved objects. (11 days ago)
-	\* 15c427c Use doubles instead of floats for conversions when compari.. (11 days ago)
-	\* e702b9f pjproject_bundled: Disable PJSIP_UNESCAPE_IN_PLACE (3 weeks ago)
-	\* b470aab func_odbc: Check connection status before executing queries. (3 weeks ago)
+	* d27ee3b res_sorcery_astdb: Fix creation of retrieved objects. (11 days ago)
+	* 15c427c Use doubles instead of floats for conversions when compari.. (11 days ago)
+	* e702b9f pjproject_bundled: Disable PJSIP_UNESCAPE_IN_PLACE (3 weeks ago)
+	* b470aab func_odbc: Check connection status before executing queries. (3 weeks ago)
 	<snip>
 	$
 
@@ -146,8 +146,8 @@ Useful Commands and Tips
 	```
 
 	$ git cdiff 13.9.0..13.9.1
-	\* d27ee3b res_sorcery_astdb: Fix creation of retrieved objects. (11 days ago)
-	\* 15c427c Use doubles instead of floats for conversions when compari.. (11 days ago)
+	* d27ee3b res_sorcery_astdb: Fix creation of retrieved objects. (11 days ago)
+	* 15c427c Use doubles instead of floats for conversions when compari.. (11 days ago)
 	<snip>
 	$
 
@@ -161,13 +161,13 @@ Useful Commands and Tips
 	```
 
 	$ git cdiff --cherry-pick --right-only 13.8...certified/13.8
-	\* b9a28cc udptl: Don't eat sequence numbers until OK is received (5 days ago)
-	| \* f85c77a chan_sip: Prevent extra Session-Expires headers from bein.. (6 days ago)
+	* b9a28cc udptl: Don't eat sequence numbers until OK is received (5 days ago)
+	| * f85c77a chan_sip: Prevent extra Session-Expires headers from bein.. (6 days ago)
 	|/ 
-	\* 8bf050b config_transport: Tell pjproject to allow all SSL/TLS pro.. (10 days ago)
-	\* 4fc2c98 res_pjsip_authenticator_digest: Don't use source port in n.. (2 weeks ago)
-	\* 4e7791d file: Ensure nativeformats remains valid for lifetime of u.. (3 weeks ago)
-	\* c4426f1 res_pjsip: disable multi domain to improve realtime perfor.. (3 weeks ago)
+	* 8bf050b config_transport: Tell pjproject to allow all SSL/TLS pro.. (10 days ago)
+	* 4fc2c98 res_pjsip_authenticator_digest: Don't use source port in n.. (2 weeks ago)
+	* 4e7791d file: Ensure nativeformats remains valid for lifetime of u.. (3 weeks ago)
+	* c4426f1 res_pjsip: disable multi domain to improve realtime perfor.. (3 weeks ago)
 	<snip>
 	$
 

--- a/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Subversion-Usage.md
+++ b/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Subversion-Usage.md
@@ -25,7 +25,7 @@ The following should be placed in the `~/.subversion/servers` file:
 
 ```
 [groups]
-digium = \*.digium.com
+digium = *.digium.com
 
 [digium]
 ssl-client-cert-file = /home/<username>/.subversion/<name>-cert.p12
@@ -202,7 +202,7 @@ Use the following commands to enable automerge on a developer branch:
 
 ```
 $ cd my-fun-branch
-$ svn ps automerge '\*' .
+$ svn ps automerge '*' .
 $ svn ps automerge-email 'me@example.com' .
 $ svn commit -m "initialize automerge"
 
@@ -232,7 +232,7 @@ Running the `svnmerge` tool will merge in the changes that cause your branch to 
 
 ```
 $ svn resolved path/to/conflicted/file
-$ svn ps automerge '\*' .
+$ svn ps automerge '*' .
 $ svn commit -m "resolve conflict, enable automerge"
 
 ```

--- a/docs/Operation/Asterisk-Command-Line-Interface/CLI-Syntax-and-Help-Commands.md
+++ b/docs/Operation/Asterisk-Command-Line-Interface/CLI-Syntax-and-Help-Commands.md
@@ -37,7 +37,7 @@ Listing commands and showing usage
 Once on the console, the 'help' alias (for 'core show help') may be used to see a large list of commands available for use.
 
 ```
-\*CLI> help
+*CLI> help
 ! -- Execute a shell command
 acl show -- Show a named ACL or list all named ACLs
 ael reload -- Reload AEL configuration
@@ -48,14 +48,14 @@ ael reload -- Reload AEL configuration
 The 'help' alias may also be used to obtain more detailed information on how to use a particular command and listing sub-commands. For example, if you type 'help core show', Asterisk will respond with a list of all commands that start with that string. If you type 'help core show version', specifying a complete command, Asterisk will respond with a usage message which describes how to use that command. As with other commands on the Asterisk console, the help command also responds to tab command line completion.
 
 ```
-\*CLI> help core show
+*CLI> help core show
 core show applications [like|describing] -- Shows registered dialplan applications
 core show application -- Describe a specific dialplan application
 ...
 
 ```
 ```
-\*CLI> help core show version
+*CLI> help core show version
 Usage: core show version
  Shows Asterisk version information.
 
@@ -69,7 +69,7 @@ A big part of working with Asterisk involves making use of Asterisk applications
 The command  **`core show application <application name>`**  or similarly  **`core show function <function name>`** will show you the usage and arguments.
 
 ```
-\*CLI> core show application Wait
+*CLI> core show application Wait
  -= Info about application 'Wait' =- 
 [Synopsis]
 Waits for some time.
@@ -93,7 +93,7 @@ Module Configuration Help
 A very useful addition to Asterisk's help and documentation features is the command **`config show help`**. This command provides detailed information about configuration files, option sections in those files, and options within the sections.
 
 ```
-\*CLI> help config show help
+*CLI> help config show help
 Usage: config show help [<module> [<type> [<option>]]]
  Display detailed information about module configuration.
  * If nothing is specified, the modules that have
@@ -116,7 +116,7 @@ Usage: config show help [<module> [<type> [<option>]]]
 For example maybe we see the 'callerid' option in a pjsip.conf file sent to us from a friend. We want to know what that option configures. If we know that pjsip.conf is provided by the res_pjsip module then we can find help on that configuration option.
 
 ```
-\*CLI> config show help res_pjsip endpoint callerid
+*CLI> config show help res_pjsip endpoint callerid
 [endpoint]
 callerid = [(null)] (Default: n/a) (Regex: False)
 

--- a/docs/Operation/Asterisk-Command-Line-Interface/Creating-and-Manipulating-Channels-from-the-CLI.md
+++ b/docs/Operation/Asterisk-Command-Line-Interface/Creating-and-Manipulating-Channels-from-the-CLI.md
@@ -22,12 +22,12 @@ Usage: channel request hangup <channel>|<all>
 An example:
 
 ```
-newtonr-laptop\*CLI> core show channels
+newtonr-laptop*CLI> core show channels
 Channel Location State Application(Data) 
 SIP/6001-00000001 (None) Up Playback(demo-congrats) 
 1 active channel
 
-newtonr-laptop\*CLI> channel request hangup SIP/6001-00000001 
+newtonr-laptop*CLI> channel request hangup SIP/6001-00000001 
 Requested Hangup on channel 'SIP/6001-00000001'
 [May 2 09:51:19] WARNING[7045][C-00000001]: app_playback.c:493 playback_exec: Playback failed on SIP/6001-00000001 for demo-congrats
 
@@ -60,7 +60,7 @@ used. If no extension is given, the 's' extension will be used.
 An example:
 
 ```
-newtonr-laptop\*CLI> channel originate SIP/6001 extension 9999@somecontext
+newtonr-laptop*CLI> channel originate SIP/6001 extension 9999@somecontext
  == Using SIP RTP CoS mark 5
  -- Called 6001
  -- SIP/6001-00000004 is ringing
@@ -91,7 +91,7 @@ An example:
  -- Executing [100@from-internal:1] Playback("SIP/6001-00000005", "demo-congrats") in new stack
  > 0x7f07ec03e560 -- Probation passed - setting RTP source address to 10.24.18.16:4048
  -- <SIP/6001-00000005> Playing 'demo-congrats.gsm' (language 'en')
-newtonr-laptop\*CLI> channel redirect SIP/6001-00000005 somecontext,9999,1
+newtonr-laptop*CLI> channel redirect SIP/6001-00000005 somecontext,9999,1
 Channel 'SIP/6001-00000005' successfully redirected to somecontext,9999,1
 [May 2 09:56:28] WARNING[7056][C-00000005]: app_playback.c:493 playback_exec: Playback failed on SIP/6001-00000005 for demo-congrats
  -- Executing [9999@somecontext:1] VoiceMailMain("SIP/6001-00000005", "") in new stack

--- a/docs/Operation/Running-Asterisk/index.md
+++ b/docs/Operation/Running-Asterisk/index.md
@@ -28,7 +28,7 @@ License version 2 and other licenses; you are welcome to redistribute it under
 certain conditions. Type 'core show license' for details.
 =========================================================================
 Connected to Asterisk 11.9.0 currently running on asterisk-server (pid = 26246)
-asterisk-server\*CLI> 
+asterisk-server*CLI> 
 
 ```
 
@@ -40,7 +40,7 @@ asterisk-server\*CLI>
 On this Page* To disconnect from a connected remote console, simply hit **Ctrl+C**:
 
 ```
-asterisk-server\*CLI> 
+asterisk-server*CLI> 
 Disconnected from Asterisk server
 Asterisk cleanly ending (0).
 Executing last minute cleanups
@@ -49,7 +49,7 @@ Executing last minute cleanups
 * To shut down Asterisk, issue `core stop gracefully`:
 
 ```
-asterisk-server\*CLI> core stop gracefully
+asterisk-server*CLI> core stop gracefully
 Disconnected from Asterisk server
 Asterisk cleanly ending (0).
 Executing last minute cleanups
@@ -76,7 +76,7 @@ certain conditions. Type 'core show license' for details.
 Connected to Asterisk 11.9.0 currently running on asterisk-server (pid = 26246)
 [May 16 17:02:50] NOTICE[27035]: loader.c:1323 load_modules: 287 modules will be loaded.
 Asterisk Ready.
-\*CLI> 
+*CLI> 
 
 ```
 Adding Verbosity


### PR DESCRIPTION
Inside a code block, `*` and `-` and `_` are not special and should
not be escaped.