### PR TITLE
Fix formatting typo

### DIFF
--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Checking-Asterisk-Requirements.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Checking-Asterisk-Requirements.md
@@ -1,4 +1,4 @@
- ---
+---
 title: Checking Asterisk Requirements
 pageid: 4817512
 ---


### PR DESCRIPTION
https://docs.asterisk.org/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Checking-Asterisk-Requirements/

A space causes the metadata to be rendered
<img width="537" height="280" alt="image" src="https://github.com/user-attachments/assets/f84978a4-3e5b-47f1-b4f0-8878f769c7af" />
