### PR TITLE
Fix link to Return application in Gosub page

### DIFF
--- a/docs/Configuration/Dialplan/Subroutines/Gosub.md
+++ b/docs/Configuration/Dialplan/Subroutines/Gosub.md
@@ -15,7 +15,7 @@ Other dialplan applications, such as `Dial` and `Queue` make use of `Gosub` func
 Defining a dialplan context for use with Gosub
 ==============================================
 
-No special syntax is needed when defining the dialplan code that you want to call with `Gosub`, *unless* you want to return back to where you called `Gosub` from. In the case of wanting to return, then you should call the `[Return](/Latest_API/API_Documentation/Dialplan_Applications/Return)` application.
+No special syntax is needed when defining the dialplan code that you want to call with `Gosub`, *unless* you want to return back to where you called `Gosub` from. In the case of wanting to return, then you should call the [Return](/Latest_API/API_Documentation/Dialplan_Applications/Return) application.
 
 Here is an example of dialplan we could call with `Gosub` when we don't wish to return.
 


### PR DESCRIPTION
<img width="1905" height="166" alt="Screenshot 2025-12-03 at 11 17 32" src="https://github.com/user-attachments/assets/903b524b-9d1d-43fa-a595-1133b222be0c" />

Current Gosub page contains incorrect markdown for the link to the Return dialplan application