### PR TITLE
Remove 'On This Page' from a lot of pages

### DIFF
--- a/docs/Configuration/Applications/Asterisk-Queues/Building-Queues.md
+++ b/docs/Configuration/Applications/Asterisk-Queues/Building-Queues.md
@@ -24,7 +24,6 @@ The first thing we want to do is register a couple of SIP devices to our server.
 
 In sip.conf, we add the following to the bottom of our file:
 
-On This Page
 
 ```
 sip.conf

--- a/docs/Configuration/Applications/Conferencing-Applications/ConfBridge/ConfBridge-AMI-Actions.md
+++ b/docs/Configuration/Applications/Conferencing-Applications/ConfBridge/ConfBridge-AMI-Actions.md
@@ -32,7 +32,7 @@ ListItems: 1
 
 ```
 
-On This PageConfbridgeListRooms
+ConfbridgeListRooms
 -------------------
 
 Lists data about all active conferences. ConfbridgeListRooms will follow as separate events, followed by a final event called ConfbridgeListRoomsComplete.

--- a/docs/Configuration/Applications/Conferencing-Applications/ConfBridge/ConfBridge-AMI-Events.md
+++ b/docs/Configuration/Applications/Conferencing-Applications/ConfBridge/ConfBridge-AMI-Events.md
@@ -17,7 +17,7 @@ Conference: 1111
 
 ```
 
-On This PageConfbridgeJoin
+ConfbridgeJoin
 --------------
 
 This event is sent when a user joins a conference - either one already in progress or as the first user to join a newly instantiated bridge.

--- a/docs/Configuration/Applications/Conferencing-Applications/ConfBridge/ConfBridge-Functions.md
+++ b/docs/Configuration/Applications/Conferencing-Applications/ConfBridge/ConfBridge-Functions.md
@@ -8,7 +8,7 @@ Function CONFBRIDGE
 
 The CONFBRIDGE dialplan function is used to set customized Bridge and/or User Profiles on a channel for the ConfBridge application. It uses the same options defined in confbridge.conf and allows the creation of dynamic, dialplan-driven conferences.
 
-On This PageSyntax
+Syntax
 ------
 
 ```

--- a/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Asterisk-PJSIP-Troubleshooting-Guide.md
+++ b/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Asterisk-PJSIP-Troubleshooting-Guide.md
@@ -29,7 +29,6 @@ Unrecognized Endpoint
 
 All inbound SIP traffic to Asterisk must be matched to a configured endpoint. If Asterisk is unable to determine which endpoint the SIP request is coming from, then the incoming request will be rejected. If you are seeing messages like:
 
-On this Page
 
 ```
 [2014-10-13 16:12:17.349] DEBUG[27284]: res_pjsip_endpoint_identifier_user.c:106 username_identify: Could not identify endpoint by username 'eggowaffles'

--- a/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Configuring-Outbound-Registrations.md
+++ b/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Configuring-Outbound-Registrations.md
@@ -18,7 +18,6 @@ Configuration options
 
 A list of outbound registration configuration options can be found on [this page](/Latest_API/API_Documentation/Module_Configuration/res_pjsip_outbound_registration). Here is a simple example configuration for an outbound registration to a provider:
 
-On this Page
 
 pjsip.conf
 

--- a/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Configuring-res_pjsip-for-Presence-Subscriptions.md
+++ b/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Configuring-res_pjsip-for-Presence-Subscriptions.md
@@ -12,7 +12,6 @@ Capabilities
 ============
 
 Asterisk's PJSIP channel driver provides the same presence subscription capabilities as `chan_sip` does. This means that [RFC 3856](http://tools.ietf.org/html/rfc3856) presence and [RFC 4235](http://www.rfc-editor.org/rfc/rfc4235.txt) dialog info are supported. Presence subscriptions support [RFC 3863](http://tools.ietf.org/html/rfc3863) PIDF+XML bodies as well as [XPIDF+XML](http://tools.ietf.org/html/draft-rosenberg-impp-pidf-00). Beyond that, Asterisk also supports subscribing to [RFC 4662](http://tools.ietf.org/html/rfc4662) lists of presence resources.  
-On this Page
 
 extensions.conf
 

--- a/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Migrating-from-chan_sip-to-res_pjsip.md
+++ b/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Migrating-from-chan_sip-to-res_pjsip.md
@@ -40,7 +40,6 @@ Writing pjsip.conf
 
 ```
 
-On this Page
 
 Side by Side Examples of sip.conf and pjsip.conf Configuration
 ==============================================================

--- a/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Resource-List-Subscriptions-RLS.md
+++ b/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/Resource-List-Subscriptions-RLS.md
@@ -12,7 +12,6 @@ In a PBX environment, it is common for SIP devices to subscribe to many resource
 
 * In a situation where all phones boot up simultaneously, each of the phones will be sending out their SIP SUBSCRIBEs nearly simultaneously, placing a larger-than-average burden on the Asterisk server's CPU.
 * In the SIP stack, N-squared long-term SIP dialogs have to be maintained, tying up more system resources (e.g. memory).
-On this Page
 
 These limitations can drastically limit the number of devices a PBX administrator can use with an Asterisk system. Even if the hardware is capable of handling the mean traffic of, say, 200 users, it may be required to limit the number of users to 50 or fewer because of the N-squared subscriptions generating so much simultaneous traffic.
 

--- a/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/res_pjsip-Configuration-Examples.md
+++ b/docs/Configuration/Channel-Drivers/SIP/Configuring-res_pjsip/res_pjsip-Configuration-Examples.md
@@ -45,7 +45,6 @@ max_contacts=1
 * auth= is used for the endpoint as opposed to outbound_auth= since we want to allow inbound registration for this endpoint
 * max_contacts= is set to something non-zero as we want to allow contacts to be created through registration
 
-On this Page
 
 A SIP trunk to your service provider, including outbound registration
 ---------------------------------------------------------------------

--- a/docs/Configuration/Core-Configuration/Named-ACLs.md
+++ b/docs/Configuration/Core-Configuration/Named-ACLs.md
@@ -20,7 +20,6 @@ Named ACLs can be defined statically in *acl.conf*. Each context in *acl.conf* d
 | deny | IP address [/Mask] | An IP address to deny, with an optional subnet mask to apply |
 | permit | IP address [/Mask] | An IP address to allow, with an optional subnet mask to apply |
 
-On This Page
 
 #### Examples
 

--- a/docs/Configuration/Dialplan/Lua-Dialplan-Configuration/Dialplan-to-Lua-Reference.md
+++ b/docs/Configuration/Dialplan/Lua-Dialplan-Configuration/Dialplan-to-Lua-Reference.md
@@ -10,7 +10,6 @@ Extension Patterns
 
 Extension pattern matching syntax on logic works the same for `extensions.conf` and `extensions.lua`.
 
-50%
 
 extensions.conf
 ---------------
@@ -24,7 +23,6 @@ exten => _2XX,1,Voicemail(${EXTEN:1})
 
 ```
 
-50%
 
 extensions.lua
 --------------
@@ -47,7 +45,6 @@ end
 Context Includes
 ----------------
 
-50%
 
 extensions.conf
 ---------------
@@ -68,7 +65,6 @@ include => users
 
 ```
 
-50%
 
 extensions.lua
 --------------
@@ -98,7 +94,6 @@ extensions = {
 Loops
 -----
 
-50%
 
 extensions.conf
 ---------------
@@ -113,7 +108,6 @@ exten => 100,n,EndWhile
 
 ```
 
-50%
 
 extensions.lua
 --------------
@@ -130,7 +124,6 @@ end
 Variables
 ---------
 
-50%
 
 extensions.conf
 ---------------
@@ -142,7 +135,6 @@ exten => 100,n,Verbose(my_variable = ${my_variable})
 
 ```
 
-50%
 
 extensions.lua
 --------------
@@ -157,7 +149,6 @@ app.verbose("my_variable = " .. channel.my_variable:get())
 Applications
 ------------
 
-50%
 
 extensions.conf
 ---------------
@@ -168,7 +159,6 @@ exten => 100,1,Dial("SIP/100",,m)
 
 ```
 
-50%
 
 extensions.lua
 --------------
@@ -184,7 +174,6 @@ Macros/GoSub
 
 *Macros can be defined in pbx_lua by naming a context 'macro-\*' just as in `extensions.conf`, but generally where you would use macros or gosub in `extensions.conf` you would simply use a function in lua.*
 
-50%
 
 extensions.conf
 ---------------
@@ -200,7 +189,6 @@ exten => 100,1,Macro(dial,SIP/100)
 
 ```
 
-50%
 
 extensions.lua
 --------------
@@ -225,7 +213,6 @@ Goto
 
 *While `Goto` is an extenstions.conf staple, it should generally be avoided in pbx_lua in favor of functions.*
 
-50%
 
 extensions.conf
 ---------------
@@ -240,7 +227,6 @@ exten => 102,n,Hangup
 
 ```
 
-50%
 
 extensions.lua
 --------------

--- a/docs/Configuration/Dialplan/index.md
+++ b/docs/Configuration/Dialplan/index.md
@@ -20,4 +20,3 @@ Example dialplan
 
 The example dial plan, in the configs/samples/extensions.conf.sample file is installed as extensions.conf if you run "make samples" after [installation of Asterisk](/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source). The sample file includes many examples of dialplan programming for specific scenarios and environments often common to Asterisk implementations.
 
-On This PageTopics

--- a/docs/Configuration/Features/Feature-Code-Call-Transfers.md
+++ b/docs/Configuration/Features/Feature-Code-Call-Transfers.md
@@ -18,7 +18,6 @@ Transfer features provided by the Asterisk core are configured in features.conf 
 
 Channel driver technologies such as chan_sip and chan_pjsip have native capability for various transfer types. That native transfer functionality is independent of this core transfer functionality. The core feature code transfer functionality is channel agnostic.
 
-On this Page
 
 Blind transfer
 --------------

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Asterisk-Configuration-for-ARI.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Asterisk-Configuration-for-ARI.md
@@ -21,7 +21,6 @@ HTTP Server
 
 The HTTP server in Asterisk is configured via `http.conf`. Note that this does not describe all of the options available via `http.conf` - rather, it lists the most useful ones for ARI.
 
-On This Page
 
 | Section | Parameter | Type | Default | Description |
 | --- | --- | --- | --- | --- |

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/ARI-and-Bridges-Bridge-Operations.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/ARI-and-Bridges-Bridge-Operations.md
@@ -17,7 +17,6 @@ This example ARI application will do the following:
 2. When that channel enters into the Stasis application, the original channel will be removed from the holding bridge, a mixing bridge will be created, and the two channels will be put in it.
 3. If either channel hangs up, the other channel will also be hung up.
 4. Once the dialed channel exists the Stasis application, the mixing bridge will be destroyed.
-On This Page
 
 Dialplan
 --------

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/ARI-and-Bridges-Holding-Bridges.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/ARI-and-Bridges-Holding-Bridges.md
@@ -22,7 +22,7 @@ POST /bridges/{bridge_id}/addChannel?channel=12345&role=participant
 
 ```
 
-On This PageAdding a channel as an announcer
+Adding a channel as an announcer
 --------------------------------
 
 To add a channel as an announcer to a holding bridge, you must specify a role of `announcer`:

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/index.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Bridges/index.md
@@ -24,7 +24,7 @@ When a bridge is created through ARI, there are a number of attributes that can 
 * `mixing` - specify that media should be passed between all channels in the bridge. This attribute cannot be used with `holding`.
 * `dtmf_events` - specify that media should be decoded within Asterisk so that DTMF can be recognized. If this is not specified, then DTMF events may not be raised due to the media being passed directly between the channels in the bridge. This attribute only impacts how media is mixed when the `mixing` attribute is used.
 * `proxy_media` - specify that media should always go through Asterisk, even if it could be redirected between clients. This attribute only impacts how media is mixed when the `mixing` attribute is used.
-On This PageBridges in Depth* `holding` - specify that the channels in the bridge should be entertained with some media. Channels in the bridge have two possible roles: a participant or an announcer. Media between participant channels is not shared; media from an announcer channel is played to all participant channels.
+Bridges in Depth* `holding` - specify that the channels in the bridge should be entertained with some media. Channels in the bridge have two possible roles: a participant or an announcer. Media between participant channels is not shared; media from an announcer channel is played to all participant channels.
 
 Depending on the combination of attributes selected when a bridge is created, different mixing technologies may be used for the participants in the bridge. Asterisk will attempt to use the most performant mixing technology that it can based on the channel types in the bridge, subject to the attributes specified when the bridge was created.
 

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/index.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/Introduction-to-ARI-and-Media-Manipulation/index.md
@@ -17,7 +17,6 @@ The following ARI client libraries are used in the code samples on these pages
 
 * Python code samples use [ari-py](https://github.com/asterisk/ari-py)
 * Node.js samples use [node-ari-client](https://github.com/asterisk/node-ari-client)
-40%On This Page
 
 Media In DepthAll of the code presented here has been tested with Asterisk 13 and works as intended. That being said, the code samples given are intended more to demonstrate the capabilities of ARI than to be a best practices guide for writing an application or to illustrate watertight code. Error-handling is virtually non-existent in the code samples. For a real application, Python calls to ARI should likely be in `try-catch` blocks in case there is an error, and Node.js calls to ARI should provide callbacks that detect if there was an error.
 

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/The-Asterisk-Resource/index.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/The-Asterisk-Resource/index.md
@@ -8,7 +8,7 @@ The Asterisk Resource
 
 While the [primary purpose of ARI](/Configuration/Interfaces/Asterisk-REST-Interface-ARI/#ari-an-interface-for-communications-applications) is to allow developers to build their own communications applications using Asterisk as a media engine, there are other resources in the API that are useful outside of this use case. One of these is the `asterisk` resource. This resource not only provides information about the running Asterisk instance, but also exposes resources and operations that allow an external system to manipulate the overall Asterisk system.
 
-On This PageMore DetailRetrieving System Information
+Retrieving System Information
 =============================
 
 The `asterisk` resource provides the ability to retrieve basic information about the running Asterisk process. This includes:

--- a/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/index.md
+++ b/docs/Configuration/Interfaces/Asterisk-REST-Interface-ARI/index.md
@@ -20,7 +20,7 @@ Not long into the project, two application programming interfaces (APIs) were ad
 
 Both of these interfaces are powerful and opened up a wide range of integration possibilities. Using AGI, remote dialplan execution could be enabled, which allowed developers to integrate Asterisk with PHP, Python, Java, and other applications. Using AMI, the state of Asterisk could be displayed, calls initiated, and the location of channels controlled. Using both APIs together, complex applications using Asterisk as the engine *could* be developed.
 
-40%On This PageARI In More DetailHowever, there are some drawbacks to using AMI and AGI to create custom communication applications:
+However, there are some drawbacks to using AMI and AGI to create custom communication applications:
 
 1. AGI is synchronous and blocks the thread servicing the AGI when an Asterisk action is taken on the channel. When creating a communications application, you will often want to respond to changes in the channel (DTMF, channel state, etc.); this is difficult to do with AGI by itself. Coordinating with AMI events can be challenging.
 2. The dialplan can be limiting. Even with AMI and AGI, your fundamental operations are limited to what can be executed on a channel. While powerful, there are other primitives in Asterisk that are not available through those APIs: bridges, endpoints, device state, message waiting indications, and the actual media on the channels themselves. Controlling those through AMI and AGI can be difficult, and can often involve complex dialplan manipulation to achieve.

--- a/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Getting-Asterisk-Connected-to-MySQL-via-ODBC.md
+++ b/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Getting-Asterisk-Connected-to-MySQL-via-ODBC.md
@@ -12,7 +12,7 @@ This is a short tutorial on how to quickly setup Asterisk to use MySQL, the ODBC
 There are three basic steps to install and configure MySQL for Asterisk.* Install MySQL server package and start the DB service.
 * Secure the installation if appropriate.
 * Configure a user and database for Asterisk in MySQL
-On This Page### Install MySQL server package and start the DB service
+### Install MySQL server package and start the DB service
 
 ```bash title=" " linenums="1"
 # sudo yum install mysql-server

--- a/docs/Deployment/Reference-Use-Cases-for-Asterisk/Super-Awesome-Company.md
+++ b/docs/Deployment/Reference-Use-Cases-for-Asterisk/Super-Awesome-Company.md
@@ -17,7 +17,6 @@ Background
 
 SAC, founded in 2015 by the noted daredevil Lindsey Freddie, the first person to BASE jump the Burj Khalifa with a paper napkin in place of a parachute, designs and delivers strategic software solutions for the multi-level marketing industry. Humbly beginning in Freddie’s garage as a subsidiary of her paper delivery route, SAC has recently moved into modern offices, complete with running water, garbage collection, and access to the Internet and the regular telephone network - a substantial upgrade from the garage-based two cans and a string, water well and composting landfill.
 
-On this Page
 
 Phase 1, "We're a Business"
 ===========================

--- a/docs/Deployment/Troubleshooting/Troubleshooting-Asterisk-Module-Loading.md
+++ b/docs/Deployment/Troubleshooting/Troubleshooting-Asterisk-Module-Loading.md
@@ -25,7 +25,6 @@ Asterisk has started successfully and the module providing the missing functiona
 
 The reason for the failure to load or run is typically invalid configuration or a failure to parse the configuration for the module.
 
-On this Page
 
 Solution
 ========

--- a/docs/Development/Debugging/Reference-Count-Debugging.md
+++ b/docs/Development/Debugging/Reference-Count-Debugging.md
@@ -49,7 +49,7 @@ Enabling Reference Count Logs
 
 Note /var/log/asterisk/refs is overwritten on each run of Asterisk.
 
-On This PageUsing refcounter.py to process refs log
+Using refcounter.py to process refs log
 =======================================
 
 Bug marshals can use the refcounter.py script to process and spot issues in a refs log when performing analysis.

--- a/docs/Development/Policies-and-Procedures/Bug-Fixes.md
+++ b/docs/Development/Policies-and-Procedures/Bug-Fixes.md
@@ -8,7 +8,6 @@ Overview
 
 This page documents the policy surrounding bug fixes.
 
-On This Page
 
 Policy
 ======

--- a/docs/Development/Policies-and-Procedures/C-API-Deprecation.md
+++ b/docs/Development/Policies-and-Procedures/C-API-Deprecation.md
@@ -8,7 +8,6 @@ Overview
 
 This page documents the C API deprecation process in Asterisk.
 
-On This Page
 
 Policy
 ======

--- a/docs/Development/Policies-and-Procedures/Module-Deprecation.md
+++ b/docs/Development/Policies-and-Procedures/Module-Deprecation.md
@@ -8,7 +8,6 @@ Overview
 
 This page documents the module deprecation process in Asterisk. This allows a module to be deprecated with notice and to eventually be removed.
 
-On This Page
 
 Policy
 ======

--- a/docs/Development/Policies-and-Procedures/New-Features-and-Improvements.md
+++ b/docs/Development/Policies-and-Procedures/New-Features-and-Improvements.md
@@ -8,7 +8,6 @@ Overview
 
 This page documents the new feature and improvements acceptance policy in Asterisk.
 
-On This Page
 
 Policy
 ======

--- a/docs/Development/Policies-and-Procedures/Software-Configuration-Management-Policies.md
+++ b/docs/Development/Policies-and-Procedures/Software-Configuration-Management-Policies.md
@@ -14,7 +14,6 @@ See [Asterisk Versions](/About-the-Project/Asterisk-Versions) for the approximat
 
 [//]: # (end-info)
 
-On This Page
 
 ## Major Version Branch Types
 

--- a/docs/Development/Roadmap/Asterisk-13-Projects/Resource-List-Subscriptions/index.md
+++ b/docs/Development/Roadmap/Asterisk-13-Projects/Resource-List-Subscriptions/index.md
@@ -13,7 +13,6 @@ In a PBX environment, it is common for SIP devices to subscribe to many resource
 
 These limitations can drastically limit the number of devices a PBX administrator can use with an Asterisk system. Even if the hardware is capable of handling the mean traffic of, say, 200 users, it may be required to limit the number of users to 50 or fewer because of the N-squared subscriptions problem.
 
-25%On this Page
 
 Resource List Subscriptions
 ---------------------------

--- a/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-14-Project-Media-Playlists.md
+++ b/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-14-Project-Media-Playlists.md
@@ -54,7 +54,6 @@ A `Playback` resource will support two new operations:
 
 An attempt to move past the end of the last media resource will return a 2xx response and will result in a `PlaybackFinished` event. An attempt to move prior to the beginning of the first media resource will return a 2xx response and will result in a `PlaybackStarted` event.
 
-On this Page
 
 ### Example
 

--- a/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-Beacon-Module.md
+++ b/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-Beacon-Module.md
@@ -15,7 +15,7 @@ Assumptions
 2. The module will be targeted at Asterisk versions 11, 13, and master. Some implementation differences will have to occur in the various versions.
 3. All communication will occur using encrypted transports.
 4. The communication protocol will be backwards compatible between all versions of Asterisk. Things may be added to the protocol between Asterisk versions, but not removed.
-On This PageProtocol
+Protocol
 ========
 
 Asterisk will communicate with the server using `HTTPS` to a REST API. Due to the sensitive nature of the data being transmitted, HTTP will not be supported. The specifics of the REST API will be published using Swagger such that other implementations may be developed for personal use.

--- a/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-DNS-API/index.md
+++ b/docs/Development/Roadmap/Asterisk-14-Projects/Asterisk-DNS-API/index.md
@@ -243,7 +243,6 @@ int ast_dns_resolve(const char *name, int rr_type, int rr_class, struct ast_dns_
 
 ```
 
-On this Page
 
 dns_query_set.h
 =================

--- a/docs/Fundamentals/Asterisk-Configuration/Sorcery/Sorcery-Caching.md
+++ b/docs/Fundamentals/Asterisk-Configuration/Sorcery/Sorcery-Caching.md
@@ -30,7 +30,6 @@ Not all configurable objects are managed by sorcery. The following is a list of 
 * PJSIP outbound-publish
 * PJSIP transport
 * External MWI mailboxes
-On this Page
 
 ## When Should I Use Caching?
 

--- a/docs/Fundamentals/Asterisk-Configuration/Sorcery/index.md
+++ b/docs/Fundamentals/Asterisk-Configuration/Sorcery/index.md
@@ -19,7 +19,6 @@ Added in Asterisk 12, Asterisk has a data abstraction and object persistence CRU
 
 Sorcery also provides a caching service as well as the capability for push configuration through the Asterisk REST Interface. See the section [ARI Push Configuration](/Configuration/Interfaces/Asterisk-REST-Interface-ARI/The-Asterisk-Resource/ARI-Push-Configuration) for more information on that topic.
 
-On This Page
 
 In This Section
 

--- a/docs/Fundamentals/Directory-and-File-Structure.md
+++ b/docs/Fundamentals/Directory-and-File-Structure.md
@@ -37,7 +37,6 @@ astvarlibdir => /var/lib/asterisk
 
 Additional library elements and files containing data used in runtime are put here.
 
-On This Page
 
 Database Directory
 ------------------

--- a/docs/Fundamentals/Key-Concepts/Bridges.md
+++ b/docs/Fundamentals/Key-Concepts/Bridges.md
@@ -8,7 +8,6 @@ Overview
 
 In Asterisk, a bridge is the construct that shares media among [Channels](/Fundamentals/Key-Concepts/Channels). While a channel represents the path of communication between Asterisk and some device, a bridge is how that path of communication is shared. While channels are in a bridge, their media is exchanged in a manner dictated by the bridge's type. While we generally think of media being directed among channels, media can also be directed from Asterisk to the channels in a bridge. This can be the case in some conferences, where Music on Hold (MoH) or announcements are played for waiting channels.
 
-On this Page
 
 Creation
 --------

--- a/docs/Fundamentals/Key-Concepts/States-and-Presence/Device-State.md
+++ b/docs/Fundamentals/Key-Concepts/States-and-Presence/Device-State.md
@@ -20,7 +20,6 @@ Common Device State Providers
 
 *Device state providers* are the components of Asterisk that provide some state information for their resources. The device state providers available in Asterisk will depend on the version of Asterisk you are using, what modules you have installed and how those modules are configured. Here is a list of the common *device state identifiers* you will see and what Asterisk component provides the resources and state.
 
-On this Page
 
 | Device State Identifier | Device State Provider |
 | --- | --- |

--- a/docs/Fundamentals/Key-Concepts/States-and-Presence/Presence-State.md
+++ b/docs/Fundamentals/Key-Concepts/States-and-Presence/Presence-State.md
@@ -18,7 +18,7 @@ While the architectures of presence state and device state support in Asterisk a
 * Asterisk cannot infer presence state changes the same way it can device state changes. For instance, when a SIP endpoint is on a call, Asterisk can infer that the device is being used and report the device state as `in use`. Asterisk cannot infer whether a user of such a device does not wish to be disturbed or would rather chat, though. Thus, all presence state changes have to be manually enacted.
 * Asterisk does not take presence into consideration when determining availability of a device. For instance, members of a queue whose device state is `busy` will not be called; however, if that member's device is `not in use` but his presence is `away` then Asterisk will still attempt to call the queue member.
 * Asterisk cannot aggregate multiple presence states into a single combined state. Multiple device states can be listed in an extension's hint priority to have a combined state reported. Presence state support in Asterisk lacks this concept.
-On this PagePresence States
+Presence States
 ===============
 
 * `not_set`: No presence state has been set for this entity.

--- a/docs/Fundamentals/Key-Concepts/States-and-Presence/Querying-and-Manipulating-State.md
+++ b/docs/Fundamentals/Key-Concepts/States-and-Presence/Querying-and-Manipulating-State.md
@@ -21,7 +21,6 @@ devstate list -- List currently known custom device states
 
 ```
 
-On this Page
 
 Extension State
 ===============

--- a/docs/Fundamentals/Key-Concepts/The-Stasis-Message-Bus.md
+++ b/docs/Fundamentals/Key-Concepts/The-Stasis-Message-Bus.md
@@ -15,7 +15,7 @@ In Asterisk 12, a new core component was added to Asterisk: the Stasis Message B
 
 While the Stasis Message Bus is mostly of interest to those developing Asterisk, its existence is a useful piece of information in understanding how the Asterisk architecture works.
 
-On This PageKey Concepts
+Key Concepts
 ============
 
 The Stasis Message Bus has many concepts that work in concert together. Some of the most important are:

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Building-and-Installing-DAHDI.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Building-and-Installing-DAHDI.md
@@ -22,7 +22,6 @@ See [What to Download?](/Getting-Started/Installing-Asterisk/Installing-Asterisk
 
 [//]: # (end-note)
 
-On This Page
 
 Starting with DAHDI-Linux-complete version 2.8.0+2.8.0, all files necessary to install DAHDI are available in the complete tarball. Therefore, all you need to do to install DAHDI is:
 

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Checking-Asterisk-Requirements.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Checking-Asterisk-Requirements.md
@@ -28,7 +28,7 @@ Once a dependency is resolved, run **configure** again to make sure the missing 
 
 [//]: # (end-tip)
 
-On this PageUpon successful completion of **./configure**, you should see a message that looks similar to the one shown below. (Obviously, your host CPU type may be different than the below.)
+Upon successful completion of **./configure**, you should see a message that looks similar to the one shown below. (Obviously, your host CPU type may be different than the below.)
 
 ```
               .$$$$$$$$$$$$$$$=..     

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-on-Non-Linux-Operating-Systems/Asterisk-on-OpenSolaris.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-on-Non-Linux-Operating-Systems/Asterisk-on-OpenSolaris.md
@@ -6,8 +6,6 @@ pageid: 12550288
 Asterisk on Solaris 10 and OpenSolaris
 --------------------------------------
 
-###### On this page
-
 ### Digium's Support Status
 
 According to the README file from 1.6.2: "Asterisk has also been 'ported' and reportedly runs properly on other operating systems as well, including Sun Solaris, Apple's Mac OS X, Cygwin, and the BSD variants." Digium's developers have also been doing a good job of addressing build and run-time issues encountered with Asterisk on Solaris.

--- a/docs/Historical-Documentation/Development/Asterisk-Project-Infrastructure-Future/index.md
+++ b/docs/Historical-Documentation/Development/Asterisk-Project-Infrastructure-Future/index.md
@@ -15,7 +15,6 @@ This page describes the general future of the Asterisk project infrastructure. T
 
 [//]: # (end-note)
 
-On this Page
 
 User Accounts
 =============

--- a/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Code-Review/Continuous-Integration.md
+++ b/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Code-Review/Continuous-Integration.md
@@ -12,7 +12,7 @@ For a long time, the Asterisk project has used continuous integration as a means
 
 Users who are here as a result of a failed test (typically noted on a code review by the 'zuul' user) should read the section "[What To Do When Your Patch Fails](#fixing_patch)."
 
-On This PageInfrastructure
+Infrastructure
 ==============
 
 ![](Gerrit-Zuul-Jenkins.png)

--- a/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Code-Review/index.md
+++ b/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Code-Review/index.md
@@ -21,7 +21,7 @@ Git-specific code review policies can be found on the [Git Usage](/Development/P
     By posting a patch to Gerrit, you agree that you are the author of the patch and that you have the license to contribute the code to the Asterisk project per the [Digium License Agreement](/Development/Policies-and-Procedures/Historical-Policies-and-Procedures/Patch-Contribution-Process/Digium-License-Agreement). If you are not the author of the patch, please arrange for the author to either post the patch themselves or comment on the respective JIRA issue that you have permission to contribute the patch to the project.  
 [//]: # (end-note)
 
-On This PageAdditional Information
+Additional Information
 
 Review Workflow
 ---------------

--- a/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Git-Usage.md
+++ b/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Git-Usage.md
@@ -34,7 +34,6 @@ The repositories on GitHub mirror the repositories on Gerrit, also provide sourc
 
 **Pull requests on GitHub WILL be ignored.**
 
-On This Page
 
 Gerrit Access
 =============

--- a/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Issue-Tracker-Workflow.md
+++ b/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Issue-Tracker-Workflow.md
@@ -15,7 +15,6 @@ This document describes how issues move through the [Asterisk Issue Tracker on G
 
 [//]: # (end-warning)
 
-On This Page
 
 Issue Tracker Workflow
 ======================

--- a/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Patch-Contribution-Process/New-Feature-Guidelines.md
+++ b/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Patch-Contribution-Process/New-Feature-Guidelines.md
@@ -12,7 +12,6 @@ At some point in time, you may find yourself asking, "I wish Asterisk did [new c
 
 This page describes how new features move through the Asterisk development process. For more information on general issue workflows, see [Issue Tracker Workflow](/Development/Policies-and-Procedures/Historical-Policies-and-Procedures/Issue-Tracker-Workflow).
 
-On This Page
 
 Before You Begin...
 ===================

--- a/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Patch-Contribution-Process/index.md
+++ b/docs/Historical-Documentation/Development/Historical-Policies-and-Procedures/Patch-Contribution-Process/index.md
@@ -15,7 +15,7 @@ As an open source project, the Asterisk project welcomes contributions that enha
 
 [//]: # (end-note)
 
-On This PageAdditional InformationSubmitting a Patch
+Submitting a Patch
 ==================
 
 1. Create an account with the Asterisk project at <https://signup.asterisk.org>.

--- a/docs/Operation/Asterisk-Audio-and-Video-Capabilities.md
+++ b/docs/Operation/Asterisk-Audio-and-Video-Capabilities.md
@@ -10,7 +10,7 @@ Asterisk supports a variety of audio and video media. Asterisk provides CODEC mo
 
 The tables on this page describe what capabilities Asterisk supports and specific details for each format.
 
-On This PageEnabling specific media support
+Enabling specific media support
 ===============================
 
 There are three basic requirements for making use of specific audio or video media with Asterisk.

--- a/docs/Operation/Asterisk-Command-Line-Interface/CLI-Syntax-and-Help-Commands.md
+++ b/docs/Operation/Asterisk-Command-Line-Interface/CLI-Syntax-and-Help-Commands.md
@@ -29,7 +29,6 @@ Command-line Completion
 
 The Asterisk CLI supports command-line completion on all commands, including many arguments. To use it, simply press the **<kbd>Tab</kbd>** key at any time while entering the beginning of any command. If the command can be completed unambiguously, it will do so, otherwise it will complete as much of the command as possible. Additionally, Asterisk will print a list of all possible matches, if possible.
 
-On this Page
 
 Listing commands and showing usage
 ----------------------------------

--- a/docs/Operation/Running-Asterisk/index.md
+++ b/docs/Operation/Running-Asterisk/index.md
@@ -37,7 +37,7 @@ asterisk-server*CLI>
 
 [//]: # (end-tip)
 
-On this Page* To disconnect from a connected remote console, simply hit **Ctrl+C**:
+* To disconnect from a connected remote console, simply hit **Ctrl+C**:
 
 ```
 asterisk-server*CLI> 


### PR DESCRIPTION
Also removes a handful of weird things like lines that just contain percentages with no context (e.g. `40%`)