### PR TITLE
docs: Clarify Tone Indications and fix svnview links

### DIFF
--- a/docs/Configuration/Core-Configuration/Asterisk-Main-Configuration-File.md
+++ b/docs/Configuration/Core-Configuration/Asterisk-Main-Configuration-File.md
@@ -8,7 +8,7 @@ The asterisk.conf file
 
 asterisk.conf is used to configure the locations of directories and files used by Asterisk, as well as options relevant to the core of Asterisk.
 
-[Link to the asterisk.conf.sample](http://svnview.digium.com/svn/asterisk/trunk/configs/asterisk.conf.sample?view=markup) file in the Asterisk trunk subversion repo. The information below could become out of date, so always check the relevant sample file in our version control system.
+[Link to the asterisk.conf.sample](https://github.com/asterisk/asterisk/blob/master/configs/samples/asterisk.conf.sample) file in the Asterisk GitHub repo. The information below could become out of date, so always check the relevant sample file in our repo.
 
 asterisk.conf has two primary contexts, shown below with some descriptions about their content.
 

--- a/docs/Configuration/Core-Configuration/Configuring-Localized-Tone-Indications.md
+++ b/docs/Configuration/Core-Configuration/Configuring-Localized-Tone-Indications.md
@@ -13,18 +13,18 @@ Note that the tones configured here are only used when Asterisk is directly gene
 Configuration
 =============
 
-The configuration file for location specific tone indications is **indications.conf**. It is read from the typical [Asterisk configuration directory](/Fundamentals/Directory-and-File-Structure). You can also view the sample of indications.conf file in your source directory at configs/modules.conf.sample or on [SVN at this link](http://svnview.digium.com/svn/asterisk/trunk/configs/samples/indications.conf.sample?view=markup).
+The configuration file which defines location specific tone indications is **indications.conf**. It is read from the typical [Asterisk configuration directory](/Fundamentals/Directory-and-File-Structure). You can view a sample configuration file [in the project source at configs/modules.conf.sample](https://github.com/asterisk/asterisk/blob/master/configs/samples/indications.conf.sample).
 
-The configuration itself consists of a 'general' section and then one or more country specific sections. (e.g. '[au]' for Australia)
+The configuration itself consists of a 'general' section and then one or more country specific sections (e.g. `[au]` for Australia).
 
-Within the general section, only the **country** option can be set. This option sets the default location tone set to be used.
+Within the general section, only the **country** option can be set. This option sets the default location tone set to be used. Ensure the country you specify has a corresponding tone configuration defined; the easiest way to ensure this is by copying the sample file (which defines tones for over 40 countries) to your Asterisk configuration directory, checking your country is defined and then changing the **country** option as shown below.
 
 ```
 [general]
-country=us
+country=de
 ```
 
-As an example, the above set the default country to the tone set for the USA.
+As an example, the above sets the default tone set country to Germany (DE).
 
 Within any location specific configuration, several tone types may be configured.
 

--- a/docs/Configuration/Core-Configuration/Logging-Configuration.md
+++ b/docs/Configuration/Core-Configuration/Logging-Configuration.md
@@ -6,7 +6,7 @@ pageid: 28315599
 Asterisk Log File Configuration
 ===============================
 
-General purpose [logging facilities](/Operation/Logging) in Asterisk can be configured in the *[logger.conf](http://svnview.digium.com/svn/asterisk/trunk/configs/logger.conf.sample?view=markup)* file. Within this file one is able to configure Asterisk to log messages to files and/or a syslog and even to the Asterisk console.  Note, the sections and descriptions listed below are meant to be informational and act as a guide (a "how to") when configuring logging in Asterisk.  Options with stated defaults don't have to be explicitly set as they will simply default to a designated value.
+General purpose [logging facilities](/Operation/Logging) in Asterisk can be configured in the *[logger.conf](https://github.com/asterisk/asterisk/blob/master/configs/samples/logger.conf.sample)* file. Within this file one is able to configure Asterisk to log messages to files and/or a syslog and even to the Asterisk console.  Note, the sections and descriptions listed below are meant to be informational and act as a guide (a "how to") when configuring logging in Asterisk.  Options with stated defaults don't have to be explicitly set as they will simply default to a designated value.
 
 General Section:
 ----------------

--- a/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Configuring-res_odbc.md
+++ b/docs/Configuration/Interfaces/Back-end-Database-and-Realtime-Connectivity/ODBC/Configuring-res_odbc.md
@@ -8,7 +8,7 @@ Overview
 
 The **res_odbc** module for Asterisk can provide Asterisk with connectivity to various database backends through ODBC (a database abstraction layer). Asterisk features such as [Asterisk Realtime Architecture](/Fundamentals/Asterisk-Configuration/Database-Support-Configuration/Realtime-Database-Configuration), [Call Detail Records](/Configuration/Reporting/Call-Detail-Records-CDR), [Channel Event Logging](/Configuration/Reporting/Channel-Event-Logging-CEL), can connect to a database through res_odbc.
 
-More details on specific options within configuration are provided in the [sample configuration file](http://svnview.digium.com/svn/asterisk/branches/11/configs/res_odbc.conf.sample?view=markup) included with Asterisk source.
+More details on specific options within configuration are provided in the [sample configuration file](https://github.com/asterisk/asterisk/blob/master/configs/samples/res_odbc.conf.sample) included with Asterisk source.
 
 We'll provide a brief guide here on how to get the res_odbc.so module configured to connect to an existing ODBC installation.
 


### PR DESCRIPTION
I was looking at this docs page and found the link to `svnview.digium.com` to be broken. These should go to GitHub instead. I've also fixed some other pages had the same issue.

I've added some detail to clarify that as the countries are defined in this file they must be present (i.e. simply copying the `[general]` snippet into an empty file won't work), so it's easiest to copy the sample config. I also changed the example from USA, which is already the default in the sample file and so restating this is less useless than using another country.