### PR TITLE
docs: Update and modernise the "Installing Asterisk" docs

### DIFF
--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Building-and-Installing-Asterisk.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Building-and-Installing-Asterisk.md
@@ -8,11 +8,18 @@ Build and Install Instructions
 
 Now we can compile and install Asterisk. To compile Asterisk, simply type make at the Linux command line.
 
+/// tip | Multithreaded Compilation
+You can add the `-jX` argument to `make` to use compile using multiple CPU threads,
+e.g. `make -j8` would use 8 threads instead of the single thread default.
+This can significantly reduce compile time on machines with multiple threads available.
+However, supplying a greater number of threads than available will instead reduce performance.
+///
+
 ```
-[root@server asterisk-14.X.Y]# make
+[root@server asterisk-22.X.Y]# make
 ```
 
-The compiling step will take several minutes, and you'll see the various file names scroll by as they are being compiled. Once Asterisk has finished compiling, you'll see a message that looks like:
+The compiling step can take several minutes, and you'll see the various file names scroll by as they are being compiled. Once Asterisk has finished compiling, you'll see a message that looks like:
 
 ```
 +--------- Asterisk Build Complete ---------+
@@ -24,10 +31,10 @@ The compiling step will take several minutes, and you'll see the various file na
 +--------- Asterisk Build Complete ---------+
 ```
 
-On this PageAs the message above suggests, our next step is to install the compiled Asterisk program and modules. To do this, use the **make** **install** command.
+As the message above suggests, our next step is to install the compiled Asterisk program and modules. To do this, use the **make install** command.
 
 ```
-[root@server asterisk-14.X.Y]# make install
+[root@server asterisk-22.X.Y]# make install
 ```
 
 When finished, Asterisk will display the following warning:
@@ -69,7 +76,7 @@ In some environments, it may be necessary or useful to modify parts of the build
 Specific flags can be passed to `gcc` when Asterisk is configured, using the `CFLAGS` and `LDFLAGS` environment variables:
 
 ```
-[root@server asterisk-14.X.Y]# ./configure CFLAGS=-pg LDFLAGS=-pg
+[root@server asterisk-22.X.Y]# ./configure CFLAGS=-pg LDFLAGS=-pg
 ```
 
 ### Debugging compilation
@@ -77,7 +84,7 @@ Specific flags can be passed to `gcc` when Asterisk is configured, using the `CF
 To see all of the flags passed to gcc, build using the `NOISY_BUILD` setting set to `YES`:
 
 ```
-[root@server asterisk-14.X.Y]# make NOISY_BUILD=yes
+[root@server asterisk-22.X.Y]# make NOISY_BUILD=yes
 ```
 
 ### Building for non-native architectures
@@ -85,9 +92,9 @@ To see all of the flags passed to gcc, build using the `NOISY_BUILD` setting set
 Generally, Asterisk attempts to optimize itself for the machine on which it is built on. On some virtual machines with virtual CPU architectures, the defaults chosen by Asterisk's compilation options will cause Asterisk to build but fail to run. To disable native architecture support, disable the `BUILD_NATIVE` option in menuselect:
 
 ```
-[root@server asterisk-14.X.Y]# menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
+[root@server asterisk-22.X.Y]# menuselect/menuselect --disable BUILD_NATIVE menuselect.makeopts
 
-[root@server asterisk-14.X.Y]# make
+[root@server asterisk-22.X.Y]# make
 ```
 
 ### Installing to a custom directory
@@ -95,7 +102,7 @@ Generally, Asterisk attempts to optimize itself for the machine on which it is b
 While there are multiple ways to sandbox an instance of Asterisk, the preferred mechanism is to use the `--prefix` option with the `configure` script:
 
 ```
-[root@server asterisk-14.X.Y]# ./configure --prefix=/usr/local/my_special_folder
+[root@server asterisk-22.X.Y]# ./configure --prefix=/usr/local/my_special_folder
 ```
 
 Note that the default value for `prefix` is `/usr/local`.
@@ -103,19 +110,20 @@ Note that the default value for `prefix` is `/usr/local`.
 Other Make Targets
 ------------------
 
-| Target            | Description                                                                                                                                                                                                                                                                                                                                         |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|                   | Executing `make` with no target is equivalent to the `all` target.                                                                                                                                                                                                                                                                                  |
-| **all**           | Compiles everything everything selected through the `configure` and `menuselect` scripts.                                                                                                                                                                                                                                                           |
+| Target            | Description |
+|-------------------|-------------|
+|                   | Executing `make` with no target is equivalent to the `all` target. |
+| **menuselect**    | Access the Menuselect system.  |
+| **all**           | Compiles everything everything selected through the `configure` and `menuselect` scripts.  |
 | **full**          | This is equivalent to `make` or `make all`, save that it will perform a more thorough investigation of the source code for documentation. This is needed to generate [AMI event documentation](/Development/Roadmap/Asterisk-11-Projects/AMI-Event-Documentation). Note that your system must have Python in order for this make target to succeed. |
-| **install**       | Installs Asterisk, building Asterisk if it has not already been built. In general, this should be executed after Asterisk has successfully compiled.                                                                                                                                                                                                |
-| **uninstall**     | Removes Asterisk binaries, sounds, man pages, headers, modules and firmware builds from the system.                                                                                                                                                                                                                                                 |
-| **uninstall-all** | Same as the `uninstall` target, but additionally removes configuration, spool directories and logs. All traces of Asterisk.                                                                                                                                                                                                                         |
-| **clean**         | Remove all files generated by make.                                                                                                                                                                                                                                                                                                                 |
-| **dist-clean**    | Remove pretty much all files generated by make and configure.                                                                                                                                                                                                                                                                                       |
-| **samples**       | Install all sample configuration files (.conf files) to `/etc/asterisk/`. Overwrites existing config files.                                                                                                                                                                                                                                         |
-| **config**        | Install init scripts (startup scripts) on your system.                                                                                                                                                                                                                                                                                              |
-| **progdocs**      | Uses doxygen to locally generate HTML development documentation from the source code.  Generated in the `doc/` subdirectory of the source; see `doc/index.html`.                                                                                                                                                                                    |
+| **install**       | Installs Asterisk, building Asterisk if it has not already been built. In general, this should be executed after Asterisk has successfully compiled.  |
+| **uninstall**     | Removes Asterisk binaries, sounds, man pages, headers, modules and firmware builds from the system.  |
+| **uninstall-all** | Same as the `uninstall` target, but additionally removes configuration, spool directories and logs. All traces of Asterisk.  |
+| **clean**         | Remove all files generated by make.  |
+| **dist-clean**    | Remove pretty much all files generated by make and configure.  |
+| **samples**       | Install all sample configuration files (.conf files) to `/etc/asterisk/`. Overwrites existing config files.  |
+| **config**        | Install init scripts (startup scripts) on your system.  |
+| **progdocs**      | Uses doxygen to locally generate HTML development documentation from the source code.  Generated in the `doc/` subdirectory of the source; see `doc/index.html`.  |
 
 /// note | Version Notice
 The `full` build target is only available in Asterisk 11 and later

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Installing-Initialization-Scripts.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Installing-Initialization-Scripts.md
@@ -6,11 +6,11 @@ pageid: 4817521
 Now that you have Asterisk compiled and installed, the last step is to install the initialization script, or `initscript`. This script starts Asterisk when your server starts, will monitor the Asterisk process in case anything *bad* happens to it, and can be used to stop or restart Asterisk as well. To install the `initscript`, use the **make** **config** command.
 
 ```
-[root@server asterisk-14.X.Y]# make config
+[root@server asterisk-22.X.Y]# make config
 ```
 
 As your Asterisk system runs, it will generate logfiles. It is recommended to install the `logrotation` script in order to compress and rotate those files, to save disk space and to make searching them or cataloguing them easier. To do this, use the **make install-logrotate** command.
 
 ```
-[root@server asterisk-14.X.Y]# make install-logrotate
+[root@server asterisk-22.X.Y]# make install-logrotate
 ```

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Installing-Sample-Files.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Installing-Sample-Files.md
@@ -14,12 +14,14 @@ for standard deployments.
 While installing the sample configuration files may be a good starting
 point for some people, they should not be viewed as recommended
 configuration for an Asterisk system.
+See [Hello World](../../Hello-World.md) for further information on
+the minimum set of required Asterisk Configs.
 ///
 
 To install a set of sample configuration files for Asterisk, type:
 
 ```
-[root@server asterisk-14.X.Y]# make samples
+[root@server asterisk-22.X.Y]# make samples
 ```
 
 Any existing sample files which have been modified will be given a **.old** file extension. For example, if you had an existing file named **extensions.conf**, it would be renamed to **extensions.conf.old** and the sample dialplan would be installed as **extensions.conf**.

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Building-and-Installing-DAHDI.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Building-and-Installing-DAHDI.md
@@ -6,6 +6,14 @@ pageid: 4817510
 Overview
 ========
 
+/// note | Don't need DAHDI?
+If you are not integrating with any traditional telephony equipment
+and you are not planning on using the
+[MeetMe](/Latest_API/API_Documentation/Dialplan_Applications/MeetMe)
+dialplan application, then you do not have to install DAHDI or libpri
+in order to use Asterisk.
+///
+
 Let's install DAHDI!
 
 On Linux, we will use the **DAHDI-linux-complete** tarball, which contains the DAHDI Linux drivers, DAHDI tools, and board firmware files. Again, we're assuming that you've untarred the tarball in the `/usr/local/src` directory, and that you'll replace X and Y with the appropriate version numbers.
@@ -15,14 +23,6 @@ See [What to Download?](/Getting-Started/Installing-Asterisk/Installing-Asterisk
 /// note | Install DAHDI before libpri
 libpri 1.4.13 and later source code depends on DAHDI include
 files. So, one must install DAHDI before installing libpri.
-///
-
-// note | Don't need DAHDI?
-If you are not integrating with any traditional telephony equipment
-and you are not planning on using the
-[MeetMe](/Latest_API/API_Documentation/Dialplan_Applications/MeetMe)
-dialplan application, then you do not have to install DAHDI or libpri
-in order to use Asterisk.
 ///
 
 Starting with DAHDI-Linux-complete version 2.8.0+2.8.0, all files necessary to install DAHDI are available in the complete tarball. Therefore, all you need to do to install DAHDI is:

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Checking-Asterisk-Requirements.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/Checking-Asterisk-Requirements.md
@@ -5,27 +5,23 @@ pageid: 4817512
 
 ## Configuring Asterisk
 
-Now it's time to compile and install Asterisk. Let's change to the directory which contains the Asterisk source code.
+Now it's time to compile and install Asterisk.
+
+In the directory containing the extracted Asterisk source code, run the **./configure** script, which will perform a number of checks on the operating system, and get the Asterisk code ready to compile on this particular server.
 
 ```
-[root@server]# cd /usr/local/src/asterisk-14.X.Y
+[root@server asterisk-22.X.Y]# ./configure
 ```
 
-Next, we'll run a command called **./configure**, which will perform a number of checks on the operating system, and get the Asterisk code ready to compile on this particular server.
-
-```
-[root@server asterisk-14.X.Y]# ./configure
-```
-
-This will run for a couple of minutes, and warn you of any missing system libraries or other dependencies. Unless you've installed all of the [System Requirements](/Operation/System-Requirements) for your version of Asterisk, the **configure** script is likely to fail. If that happens, resolve the missing dependency manually, or use the [install_prereq](#using-install_prereq) script to resolve all of the dependencies on your system.
+This will run for a couple of minutes, and warn you of any missing system libraries or other dependencies. Unless you've already installed all [System Requirements](/Operation/System-Requirements) for your version of Asterisk, the **configure** script is likely to fail. If that happens, resolve the missing dependency manually, or use the [install_prereq](#using-install_prereq) script to resolve all dependencies on your system.
 
 Once a dependency is resolved, run **configure** again to make sure the missing dependency is fixed.
 
 /// tip
-If you have many missing dependencies, you may find yourself running
+If you have many missing dependencies, you may find yourself re-running
 `configure` a lot. If that is the case, you'll do yourself a favor by
-checking the [System Requirements](/Operation/System-Requirements) or
-installing all dependencies via the `install_prereq` script.
+installing all dependencies via the [`install_prereq`](#using-install_prereq) script, or checking
+the [System Requirements](/Operation/System-Requirements) and installing manually.
 ///
 
 Upon successful completion of **./configure**, you should see a message that looks similar to the one shown below. (Obviously, your host CPU type may be different than the below.)
@@ -67,7 +63,7 @@ the following command to completely clear out any cached data from the
 Asterisk build system.
 
 ```
-[root@server asterisk-14.X.Y]# make distclean
+[root@server asterisk-22.X.Y]# make distclean
 ```
 
 You can then re-run `./configure`.
@@ -85,13 +81,10 @@ The **install_prereq** script is included with every release of Asterisk in the 
 /// warning
 You should always use your operating system's package management tools
 to ensure that your system is running the latest software *before*
-running `install_prereq`. Ubuntu 14's libsnmp-dev package, for
-instance, has an issue where it will attempt to remove critical system
-packages if the system isn't updated before an attempt is made to
-install that package.
+running `install_prereq`.
 ///
 
 ```
-[root@server asterisk-14.X.Y]# ./contrib/scripts/install_prereq install
-[root@server asterisk-14.X.Y]# ./contrib/scripts/install_prereq install-unpackaged
+[root@server asterisk-22.X.Y]# ./contrib/scripts/install_prereq install
+[root@server asterisk-22.X.Y]# ./contrib/scripts/install_prereq install-unpackaged
 ```

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/PJSIP-pjproject.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Prerequisites/PJSIP-pjproject.md
@@ -5,7 +5,7 @@ pageid: 25919783
 
 # Overview
 
-Asterisk currently contains two SIP stacks: the original **chan_sip** SIP channel driver which is a complete standalone implementation, has been present in all previous releases of Asterisk *and no longer receives core support*, and the newer **chan_pjsip** SIP stack that is based on Teluu's "[pjproject](http://www.pjsip.org/)" SIP stack. While the pjproject stack allows us to move a significant amount of code out of Asterisk, it *is* a separate, actively maintained, library that we integrate very tightly to.  This presents challenges in making sure that the versions of Asterisk and pjproject currently installed on a system are compatible.  For this reason, we've elected to "bundle" a stable, tested version of pjproject with the Asterisk distribution and integrate it into the Asterisk build process. This does not prevent you from using an external pjproject installation but it will not be supported by the Asterisk team.  See below for more info.
+Since Asterisk 21, Teluu's "[pjproject](http://www.pjsip.org/)" is used exclusively to provide the Asterisk SIP stack (**chan_pjsip**). pjproject is a separate, actively maintained, library that we integrate very tightly to.  This presents challenges in making sure that the versions of Asterisk and pjproject currently installed on a system are compatible.  For this reason, we've elected to "bundle" a stable, tested version of pjproject with the Asterisk distribution and integrate it into the Asterisk build process. This does not prevent you from using an external pjproject installation, but this will not be supported by the Asterisk team.  See below for more info.
 
 ## Using the Bundled Version of pjproject
 
@@ -26,19 +26,11 @@ The actual pjproject source code is NOT distributed with Asterisk.  Instead the 
 * **Reliability**:  You can be sure that Asterisk was tested against the bundled version.
 
 ### Usage
+/// tip
+Building the bundled pjproject requires python development libraries, if these are missing you can install them using [`./contrib/scripts/install_prereq`](./Checking-Asterisk-Requirements.md#using-install_prereq).
+///
 
-First, run `./contrib/scripts/install_prereq`.  Building the bundled pjproject requires the python development libraries which install_prereq installs.  All you have to do now is add the `--with-pjproject-bundled` option to your Asterisk `./configure` command line and remove any other `--with-pjproject` option you may have specified.
-
-```bash title=" " linenums="1"
-$ cd /path/asterisk-source-dir
-# For Asterisk 13 and 14...
-$ ./configure --with-pjproject-bundled
-# For Asterisk 15+...
-$ ./configure
-$ make && make install
-```
-
-The configure and make processes will download the correct version of pjproject, patch it, configure it, build it, and finally link Asterisk to it statically.  No changes in runtime configuration are required.  You can leave your system-installed version of pjproject in place if needed.  Once compiled with the `--with-pjproject-bundled` option, Asterisk will ignore any other installed versions of pjproject.
+The `./configure` and `make` processes will download the correct version of pjproject, patch it, configure it, build it, and finally link Asterisk to it statically.  No changes in runtime configuration are required.  You can leave any system-installed version of pjproject in place if needed. Unless compiled with the `--without-pjproject-bundled` option, Asterisk will ignore any other installed versions of pjproject.
 
 Using the bundled version of pjproject doesn't necessarily mean you need internet access to download the pjproject tarball every time you build. There are 2 ways to specify an alternate location from which to retrieve it.  First, assuming version 2.6 of pjproject is needed and `/tmp/downloads` is the directory you're going to save to, download the following files to the local directory:
 
@@ -52,8 +44,8 @@ It's important that both files be named `pjproject-<version>.tar.bz2` and `pjpro
 
 Now perform either of the following 2 steps:
 
-1. 1. Run ./configure with the `--with-externals-cache=/tmp/downloads` option.  ./configure will check there first and only download if the files aren't already there or the tarball checksum doesn't match what's in the md5 file.  This is similar to the `--with-sounds-cache` option.  BTW, the `--with-externals-cache` mechanism works for the precompiled codecs and the Digium Phone Module for Asterisk as well.  As of Asterisk 13.18, 14.7 and 15.0, the `--with-download-cache`  option can be used to specify both the externals and sounds cache directory.
-	2. Set the `PJPROJECT_URL` environment variable to any valid URL (including file:// URLs) where `./configure` can find the tarball and checksum files.  The variable can be set in your environment and exported or specified directly on the `./configure` command line.  As of Asterisk 13.18, 14.7 and 15.0, the `AST_DOWNLOAD_CACHE` environment variable can be used to specify both the externals and sounds cache directory.
+1. Run `./configure` with the `--with-externals-cache=/tmp/downloads` option, `./configure` will check there first and only download if the files aren't already there or the tarball checksum doesn't match what's in the md5 file. This is similar to the `--with-sounds-cache` option. This `--with-externals-cache` mechanism works for the precompiled codecs and the Digium Phone Module for Asterisk as well. As of Asterisk 13.18, 14.7 and 15.0, the `--with-download-cache` option can be used to specify both the externals and sounds cache directory.
+2. Set the `PJPROJECT_URL` environment variable to any valid URL (including file:// URLs) where `./configure` can find the tarball and checksum files. The variable can be set in your environment and exported or specified directly on the `./configure` command line.  As of Asterisk 13.18, 14.7 and 15.0, the `AST_DOWNLOAD_CACHE` environment variable can be used to specify both the externals and sounds cache directory.
 
 ## Building and Installing pjproject from Source
 
@@ -93,9 +85,9 @@ The first step in building and installing pjproject is configuring it using **co
 
 Additionally, Asterisk **REQUIRES** two or three options to be passed to **configure**:
 
-* + `--enable-shared` - Instruct pjproject to build shared object libraries. Asterisk will only use shared objects from pjproject.
-	+ `--prefix` - Specify root install directory for pjproject. This will be dependent on your distribution of Linux; typically this is `/usr`for most systems. The default is `/usr/local`
-	+ `--libdir` - Specify the installation location for object code libraries. This may need to be set to `/usr/lib64` for some 64-bit systems such as CentOS.
+ + `--enable-shared` - Instruct pjproject to build shared object libraries. Asterisk will only use shared objects from pjproject.
+ + `--prefix` - Specify root install directory for pjproject. This will be dependent on your distribution of Linux; typically this is `/usr`for most systems. The default is `/usr/local`
+ + `--libdir` - Specify the installation location for object code libraries. This may need to be set to `/usr/lib64` for some 64-bit systems such as CentOS.
 
 /// warning
 Failure to build Asterisk with shared pjproject object libraries

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Using-Menuselect-to-Select-Asterisk-Options.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Using-Menuselect-to-Select-Asterisk-Options.md
@@ -9,7 +9,7 @@ Using Menuselect
 The next step in the build process is to tell Asterisk which [modules](/Fundamentals/Asterisk-Architecture/Types-of-Asterisk-Modules) to compile and install, as well as set various compiler options. These settings are all controlled via a menu-driven system called **Menuselect**. To access the Menuselect system, type:
 
 ```
-[root@server asterisk-14.X.Y]# make menuselect
+[root@server asterisk-22.X.Y]# make menuselect
 ```
 
 /// note | Terminal Window
@@ -22,7 +22,7 @@ Terminal must be at least 80 x 27.
 ```
 ///
 
-The **Menuselect** menu should look like the screen-shot below. On the left-hand side, you have a list of categories, such as **Applications**, **Channel** **Drivers**, and **PBX** **Modules**. On the right-hand side, you'll see a list of modules that correspond with the select category. At the bottom of the screen you'll see two buttons. You can use the **<kbd>Tab</kbd>** key to cycle between the various sections, and press the **<kbd>Enter</kbd>** key to select or unselect a particular module. If you see **[\*]** next to a module name, it signifies that the module has been selected. If you see **\*XXX** next to a module name, it signifies that the select module cannot be built, as one of its dependencies is missing. In that case, you can look at the bottom of the screen for the line labeled **Depends** **upon**: for a description of the missing dependency.
+The **Menuselect** menu should look similar to the screen-shot below. On the left-hand side, you have a list of categories, such as **Applications**, **Channel** **Drivers**, and **PBX** **Modules**. On the right-hand side, you'll see a list of modules that correspond with the select category. At the bottom of the screen you'll see two buttons. You can use the **<kbd>Tab</kbd>** key to cycle between the various sections, and press the **<kbd>Enter</kbd>** key to select or unselect a particular module. If you see **[\*]** next to a module name, it signifies that the module has been selected. If you see **\*XXX** next to a module name, it signifies that the select module cannot be built, as one of its dependencies is missing. In that case, you can look at the bottom of the screen for the line labeled **Depends** **upon**: for a description of the missing dependency.
 
 ![](menuselect.png)
 
@@ -78,13 +78,13 @@ Controlling Menuselect
 Options in  **Menuselect** can be controlled from the command line. **Menuselect** can be built without invoking the user interface via the `menuselect.makeopts` target:
 
 ```
-[root@server asterisk-14.X.Y]# make menuselect.makeopts
+[root@server asterisk-22.X.Y]# make menuselect.makeopts
 ```
 
 Available options can be viewed using the `--help` command line parameter:
 
 ```
-[root@server asterisk-14.X.Y]# menuselect/menuselect --help
+[root@server asterisk-22.X.Y]# menuselect/menuselect --help
 ```
 
 Some of the more common options are shown below.
@@ -102,13 +102,13 @@ Listing Options
 To list all options in **Menuselect**, use the `--list-options` command line parameter:
 
 ```
-[root@server asterisk-14.X.Y]# menuselect/menuselect --list-options
+[root@server asterisk-22.X.Y]# menuselect/menuselect --list-options
 ```
 
 To list only the categories, use the `--category-list` command line parameter:
 
 ```
-[root@server asterisk-14.X.Y]# menuselect/menuselect --category-list
+[root@server asterisk-22.X.Y]# menuselect/menuselect --category-list
 MENUSELECT_ADDONS
 MENUSELECT_APPS
 MENUSELECT_BRIDGES
@@ -121,11 +121,10 @@ MENUSELECT_FUNCS
 MENUSELECT_PBX
 MENUSELECT_RES
 MENUSELECT_TESTS
+MENUSELECT_CHANNELSTORAGE
 MENUSELECT_CFLAGS
-MENUSELECT_OPTS_app_voicemail
 MENUSELECT_UTILS
 MENUSELECT_AGIS
-MENUSELECT_EMBED
 MENUSELECT_CORE_SOUNDS
 MENUSELECT_MOH
 MENUSELECT_EXTRA_SOUNDS
@@ -134,10 +133,17 @@ MENUSELECT_EXTRA_SOUNDS
 To list the options in a category, use the `--list-category` command line parameter:
 
 ```
-[root@server asterisk-14.X.Y]# menuselect/menuselect --list-category MENUSELECT_OPTS_app_voicemail
-+ FILE_STORAGE
-- ODBC_STORAGE
-- IMAP_STORAGE
+[root@server asterisk-22.X.Y]# menuselect/menuselect --list-category MENUSELECT_CHANNELS
++ chan_bridge_media
++ chan_dahdi
++ chan_iax2
++ chan_motif
++ chan_pjsip
++ chan_rtp
++ chan_websocket
++ chan_audiosocket
++ chan_console
++ chan_unistim
 ```
 
 Enabling an Option
@@ -146,14 +152,14 @@ Enabling an Option
 To enable an option in Menuselect, use the `--enable` command line parameter:
 
 ```
-[root@server asterisk-14.X.Y]# menuselect/menuselect --enable IMAP_STORAGE menuselect.makeopts
+[root@server asterisk-22.X.Y]# menuselect/menuselect --enable chan_audiosocket menuselect.makeopts
 ```
 
 /// tip | Chaining Options
 Multiple options can be chained together:
 
 ```
-[root@server asterisk-14.X.Y]# menuselect/menuselect --enable app_voicemail --enable IMAP_STORAGE menuselect.makeopts
+[root@server asterisk-22.X.Y]# menuselect/menuselect --enable app_voicemail --enable chan_audiosocket menuselect.makeopts
 ```
 ///
 
@@ -163,7 +169,7 @@ Disabling an Option
 To disable an option in **Menuselect**, use the `--disable` command line parameter:
 
 ```
-[root@server asterisk-14.X.Y]# menuselect/menuselect --disable app_voicemail menuselect.makeopts
+[root@server asterisk-22.X.Y]# menuselect/menuselect --disable app_voicemail menuselect.makeopts
 ```
 
 Enabling a Category
@@ -172,5 +178,5 @@ Enabling a Category
 An entire category can be enabled in **Menuselect** using the `--enable-category` command line parameter:
 
 ```
-[root@server asterisk-14.X.Y]# menuselect/menuselect --enable-category MENUSELECT_ADDONS menuselect.makeopts
+[root@server asterisk-22.X.Y]# menuselect/menuselect --enable-category MENUSELECT_ADDONS menuselect.makeopts
 ```

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Validating-Your-Installation.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/Validating-Your-Installation.md
@@ -3,39 +3,37 @@ title: Validating Your Installation
 pageid: 4817531
 ---
 
-Before continuing on, let's check a few things to make sure your system is in good working order. First, let's make sure the DAHDI drivers are loaded. You can use the **lsmod** under Linux to list all of the loaded kernel modules, and the **grep** command to filter the input and only show the modules that have **dahdi** in their name.
+Before continuing on, let's check a few things to make sure your system is in good working order.
+
+## Checking DAHDI
+
+/// tip | Are you using DAHDI?
+If you're not using DAHDI you can skip to [the next section](#checking-asterisk).
+///
+
+First, let's make sure the DAHDI drivers are loaded. You can use the **lsmod** under Linux to list all of the loaded kernel modules, and the **grep** command to filter the input and only show the modules that have **dahdi** in their name.
 
 ```
-[root@server asterisk-14.X.Y]# lsmod | grep dahdi
+[root@server asterisk-22.X.Y]# lsmod | grep dahdi
 ```
 
 If the command returns nothing, then DAHDI has not been started. Start DAHDI by running:
 
 ```
-[root@server asterisk-14.X.Y]# /etc/init.d/dadhi start
+[root@server asterisk-22.X.Y]# service dadhi start
 ```
 
-/// tip | Different Methods for Starting Initscripts
-Many Linux distributions have different methods for starting
-initscripts. On most Red Hat based distributions (such as Red Hat
-Enterprise Linux, Fedora, and CentOS) you can run:
-
-```
-[root@server asterisk-14.X.Y]# service dahdi start
-```
-
-Distributions based on Debian (such as Ubuntu) have a similar command,
-though it's not commonly used:
-
-```
-[root@server asterisk-14.X.Y]# invoke-rc.d dahdi start
-```
+/// tip | Different methods for starting services
+Some Linux distributions have different methods for starting
+services (traditionally called initscripts). Check your
+distribution's documentation if you have any problems with
+the commands used here.
 ///
 
 If you have DAHDI running, the output of **lsmod | grep dahdi** should look something like the output below. (The exact details may be different, depending on which DAHDI modules have been built, and so forth.)
 
 ```
-[root@server asterisk-14.X.Y]# lsmod | grep dahdi
+[root@server asterisk-22.X.Y]# lsmod | grep dahdi
 dahdi_transcode 7928 1 wctc4xxp
 dahdi_voicebus 40464 2 wctdm24xxp,wcte12xp
 dahdi 196544 12 wctdm24xxp,wcte11xp,wct1xxp,wcte12xp,wct4xxp
@@ -44,24 +42,32 @@ crc_ccitt 2096 1 dahdi
 
 Now that DAHDI is running, you can run **dahdi_hardware** to list any DAHDI-compatible devices in your system. You can also run the **dahdi_tool** utility to show the various DAHDI-compatible devices, and their current state.
 
-To check if Asterisk is running, you can use the Asterisk `initscript`.
+## Checking Asterisk
+
+To check if Asterisk is running, you can run:
 
 ```
-[root@server asterisk-14.X.Y]# /etc/init.d/asterisk status
+[root@server asterisk-22.X.Y]# service asterisk status
 asterisk is stopped
 ```
 
-To start Asterisk, we'll use the `initscript` again, this time giving it the start action:
+/// tip | Different service command output
+The output of the `service` command varies between Linux
+distributions. You are likely to see more detail, e.g.
+if your distribution uses systemd.
+///
+
+To start Asterisk, we'll use `service` again, this time giving it the start action:
 
 ```
-[root@server asterisk-14.X.Y]# /etc/init.d/asterisk start
+[root@server asterisk-22.X.Y]# service asterisk start
 Starting asterisk:
 ```
 
 When Asterisk starts, it runs as a background service (or daemon), so you typically won't see any response on the command line. We can check the status of Asterisk and see that it's running using the command below. (The process identifier, or pid, will obviously be different on your system.)
 
 ```
-[root@server asterisk-14.X.Y]# /etc/init.d/asterisk status
+[root@server asterisk-22.X.Y]# service asterisk status
 asterisk (pid 32117) is running...
 ```
 

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/What-to-Download/Installing-libsrtp.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/What-to-Download/Installing-libsrtp.md
@@ -7,4 +7,4 @@ libsrtp is a critical part of providing secure calling with Asterisk but there a
 
 As of November 2017, the minimum supported version of libsrtp supported by Asterisk is 1.5.4.  Earlier versions may allow Asterisk to compile but there were enough issues that earlier versions MAY CRASH, will NOT BE SUPPORTED and are used at your own risk.  Both Asterisk and pjproect do support libsrtp 2.x.
 
-Make sure to specify **`--with-pjproject-bundled`** when running **`./configure`** to make sure both Asterisk and pjproject are in sync with respect to library versions.
+For Asterisk versions prior to 15 make sure to specify **`--with-pjproject-bundled`** when running **`./configure`** to make sure both Asterisk and pjproject are in sync with respect to library versions.

--- a/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/What-to-Download/index.md
+++ b/docs/Getting-Started/Installing-Asterisk/Installing-Asterisk-From-Source/What-to-Download/index.md
@@ -19,7 +19,7 @@ that these releases may have larger changes made in them than LTS
 releases.
 
 Unless otherwise noted, for the purposes of this section we will
-assume that Asterisk 14 is being installed.
+assume that Asterisk 22 is being installed.
 ///
 
 Review Asterisk's [System Requirements](/Operation/System-Requirements) in order to determine what needs to be installed for the version of Asterisk you are installing. While Asterisk will look for any missing system requirements during compilation, it's often best to install these prior to configuring and compiling Asterisk.
@@ -28,31 +28,35 @@ Asterisk does come with a script, **install_prereq**, to aid in this process. If
 
 ### Downloading Asterisk
 
-Browse to <https://downloads.asterisk.org/pub/telephony/asterisk>, select [asterisk-14-current.tar.gz](https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-14-current.tar.gz), and save the file on your file system.
+Browse to <https://downloads.asterisk.org/pub/telephony/asterisk>, select [asterisk-22-current.tar.gz](https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-22-current.tar.gz), and save the file on your file system.
 
-You can also get the latest releases from the downloads page on [asterisk.org](http://asterisk.org/downloads).
+You can also get the latest releases from the downloads page on [asterisk.org](https://www.asterisk.org/downloads/).
 
 Alternatively, you can use [`wget`](https://www.gnu.org/software/wget/) to retrieve the latest release:
 
 ```
-[root@server:/usr/local/src]# wget https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-14-current.tar.gz
---2017-04-28 15:45:36-- https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-14-current.tar.gz
-Resolving downloads.asterisk.org (downloads.asterisk.org)... 76.164.171.238
-Connecting to downloads.asterisk.org (downloads.asterisk.org)|76.164.171.238|:443... connected.
+[root@server:/usr/local/src]# wget https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-22-current.tar.gz
+--2026-07-01 11:07:12--  https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-22-current.tar.gz
+Resolving downloads.asterisk.org (downloads.asterisk.org)... 165.22.184.19, 2604:a880:400:d0::14:9001
+Connecting to downloads.asterisk.org (downloads.asterisk.org)|165.22.184.19|:443... connected.
 HTTP request sent, awaiting response... 200 OK
-Length: 40692588 (39M) [application/x-gzip]
-Saving to: ‘asterisk-14-current.tar.gz’
+Length: 26672088 (25M) [application/octet-stream]
+Saving to: ‘asterisk-22-current.tar.gz’
 
-asterisk-14-current.tar.gz 100%[======================================================================>] 38.81M 3.32MB/s in 12s
+asterisk-22-current.tar.gz         100%[================================================================>]  25.44M  2.81MB/s    in 9.2s    
 
-2017-04-28 15:45:47 (3.37 MB/s) - ‘asterisk-14-current.tar.gz’ saved [40692588/40692588]
+2026-07-01 11:07:22 (2.75 MB/s) - ‘asterisk-22-current.tar.gz’ saved [26672088/26672088]
+
+FINISHED --2026-07-01 11:07:22--
+Total wall clock time: 9.7s
+Downloaded: 1 files, 25M in 9.2s (2.75 MB/s)
 ```
 
 ## Other Projects
 
 ### libpri
 
-The **libpri** library allows Asterisk to communicate with ISDN connections.You'll only need this if you are going to use DAHDI with ISDN interface hardware (such as T1/E1/J1/BRI cards).
+The **libpri** library allows Asterisk to communicate with ISDN connections. You'll only need this if you are going to use DAHDI with ISDN interface hardware (such as T1/E1/J1/BRI cards).
 
 ### DAHDI
 
@@ -60,7 +64,7 @@ The **DAHDI** library allows Asterisk to communicate with analog and digital tel
 
 DAHDI stands for Digium Asterisk Hardware Device Interface, and is a set of drivers and utilities for a number of analog and digital telephony cards, such as those manufactured by Digium. The DAHDI drivers are independent of Asterisk, and can be used by other applications. DAHDI was previously called Zaptel, as it evolved from the Zapata Telephony Project.
 
-The DAHDI code can be downloaded as individual pieces (**dahdi-linux** for the DAHDI drivers, and **dahdi-tools** for the DAHDI utilities. They can also be downloaded as a complete package called **dahdi-linux-complete**, which contains both the Linux drivers and the utilities.
+The DAHDI code can be downloaded as individual pieces: **dahdi-linux** for the DAHDI drivers, and **dahdi-tools** for the DAHDI utilities. They can also be downloaded as a complete package called **dahdi-linux-complete**, which contains both the Linux drivers and the utilities.
 
 You will only need to install DAHDI if you are going to utilize DAHDI compatible analog or digital telephony interface boards.
 
@@ -75,7 +79,7 @@ dahdi-linux, dahdi-freebsd, and so on.
 
 | Project        | Location                                                                                                |
 |----------------|---------------------------------------------------------------------------------------------------------|
-| Asterisk       | <https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-14-current.tar.gz>                      |
+| Asterisk       | <https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-22-current.tar.gz>                      |
 | libpri         | <https://downloads.asterisk.org/pub/telephony/libpri/libpri-current.tar.gz>                             |
 | dahdi-linux    | <https://downloads.asterisk.org/pub/telephony/dahdi-linux/dahdi-linux-current.tar.gz>                   |
 | dahdi-tools    | <https://downloads.asterisk.org/pub/telephony/dahdi-tools/dahdi-tools-current.tar.gz>                   |


### PR DESCRIPTION
Mostly straightforward changes to use Asterisk 22 instead of 14. Plus updates to how services are start on modern distros, update to pjsip info to reflect the removal of chan_sip, and general doc fixes and improvements.